### PR TITLE
Cuture locale text space issue resolved

### DIFF
--- a/src/ar-AE.json
+++ b/src/ar-AE.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "لا توجد سجلات",
             "actionFailureTemplate": "فشل الطلب",
-            "overflowCountTemplate": "+ $ {count} المزيد ..",
+            "overflowCountTemplate": "+${count} المزيد ..",
             "selectAllText": "اختر الكل",
             "unSelectAllText": "إلغاء تحديد الكل",
-            "totalCountTemplate": "تم تحديد $ {count}"
+            "totalCountTemplate": "تم تحديد ${count}"
         },
         "drop-down-list": {
             "noRecordsTemplate": "لا توجد سجلات",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "لا توجد سجلات",
             "actionFailureTemplate": "فشل الطلب",
-            "overflowCountTemplate": "+ $ {count} المزيد ..",
+            "overflowCountTemplate": "+${count} المزيد ..",
             "selectAllText": "اختر الكل",
             "unSelectAllText": "إلغاء تحديد الكل",
-            "totalCountTemplate": "تم تحديد $ {count}"
+            "totalCountTemplate": "تم تحديد ${count}"
         },
         "listbox": {
             "noRecordsTemplate": "لا توجد سجلات",

--- a/src/ar.json
+++ b/src/ar.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "لا توجد سجلات",
             "actionFailureTemplate": "فشل الطلب",
-            "overflowCountTemplate": "+ $ {count} المزيد ..",
+            "overflowCountTemplate": "+${count} المزيد ..",
             "selectAllText": "اختر الكل",
             "unSelectAllText": "إلغاء تحديد الكل",
-            "totalCountTemplate": "تم تحديد $ {count}"
+            "totalCountTemplate": "تم تحديد ${count}"
         },
         "drop-down-list": {
             "noRecordsTemplate": "لا توجد سجلات",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "لا توجد سجلات",
             "actionFailureTemplate": "فشل الطلب",
-            "overflowCountTemplate": "+ $ {count} المزيد ..",
+            "overflowCountTemplate": "+${count} المزيد ..",
             "selectAllText": "اختر الكل",
             "unSelectAllText": "إلغاء تحديد الكل",
-            "totalCountTemplate": "تم تحديد $ {count}"
+            "totalCountTemplate": "تم تحديد ${count}"
         },
         "listbox": {
             "noRecordsTemplate": "لا توجد سجلات",

--- a/src/cs.json
+++ b/src/cs.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "Nenalezeny žádné záznamy",
             "actionFailureTemplate": "Žádost selhala",
-            "overflowCountTemplate": "+ $ {count} další ..",
+            "overflowCountTemplate": "+${count} další ..",
             "selectAllText": "Vybrat vše",
             "unSelectAllText": "Odznačit vše",
-            "totalCountTemplate": "Vybráno $ {count}"
+            "totalCountTemplate": "Vybráno ${count}"
         },
         "drop-down-list": {
             "noRecordsTemplate": "Nenalezeny žádné záznamy",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "Nenalezeny žádné záznamy",
             "actionFailureTemplate": "Žádost selhala",
-            "overflowCountTemplate": "+ $ {count} další ..",
+            "overflowCountTemplate": "+${count} další ..",
             "selectAllText": "Vybrat vše",
             "unSelectAllText": "Odznačit vše",
-            "totalCountTemplate": "Vybráno $ {count}"
+            "totalCountTemplate": "Vybráno ${count}"
         },
         "listbox": {
             "noRecordsTemplate": "Nenalezeny žádné záznamy",

--- a/src/da.json
+++ b/src/da.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "Ingen poster fundet",
             "actionFailureTemplate": "Anmodningen mislykkedes",
-            "overflowCountTemplate": "+ $ {count} mere ..",
+            "overflowCountTemplate": "+${count} mere ..",
             "selectAllText": "Vælg alle",
             "unSelectAllText": "Fjern markering af alle",
-            "totalCountTemplate": "$ {count} valgt"
+            "totalCountTemplate": "${count} valgt"
         },
         "drop-down-list": {
             "noRecordsTemplate": "Ingen poster fundet",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "Ingen poster fundet",
             "actionFailureTemplate": "Anmodningen mislykkedes",
-            "overflowCountTemplate": "+ $ {count} mere ..",
+            "overflowCountTemplate": "+${count} mere ..",
             "selectAllText": "Vælg alle",
             "unSelectAllText": "Fjern markering af alle",
-            "totalCountTemplate": "$ {count} valgt"
+            "totalCountTemplate": "${count} valgt"
         },
         "listbox": {
             "noRecordsTemplate": "Ingen poster fundet",

--- a/src/de.json
+++ b/src/de.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "Keine Aufzeichnungen gefunden",
             "actionFailureTemplate": "Die Anfrage ist fehlgeschlagen",
-            "overflowCountTemplate": "+ $ {count} mehr ..",
+            "overflowCountTemplate": "+${count} mehr ..",
             "selectAllText": "Wählen Sie Alle",
             "unSelectAllText": "Alles wiederufen",
-            "totalCountTemplate": "$ {count} ausgewählt"
+            "totalCountTemplate": "${count} ausgewählt"
         },
         "drop-down-list": {
             "noRecordsTemplate": "Keine Aufzeichnungen gefunden",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "Keine Aufzeichnungen gefunden",
             "actionFailureTemplate": "Die Anfrage ist fehlgeschlagen",
-            "overflowCountTemplate": "+ $ {count} mehr ..",
+            "overflowCountTemplate": "+${count} mehr ..",
             "selectAllText": "Wählen Sie Alle",
             "unSelectAllText": "Alles wiederufen",
-            "totalCountTemplate": "$ {count} ausgewählt"
+            "totalCountTemplate": "${count} ausgewählt"
         },
         "listbox": {
             "noRecordsTemplate": "Keine Aufzeichnungen gefunden",

--- a/src/es.json
+++ b/src/es.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "No se encontraron registros",
             "actionFailureTemplate": "La solicitud falló",
-            "overflowCountTemplate": "+ $ {count} más ..",
+            "overflowCountTemplate": "+${count} más ..",
             "selectAllText": "Seleccionar todo",
             "unSelectAllText": "Deselecciona todo",
-            "totalCountTemplate": "$ {count} seleccionado"
+            "totalCountTemplate": "${count} seleccionado"
         },
         "drop-down-list": {
             "noRecordsTemplate": "No se encontraron registros",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "No se encontraron registros",
             "actionFailureTemplate": "La solicitud falló",
-            "overflowCountTemplate": "+ $ {count} más ..",
+            "overflowCountTemplate": "+${count} más ..",
             "selectAllText": "Seleccionar todo",
             "unSelectAllText": "Deselecciona todo",
-            "totalCountTemplate": "$ {count} seleccionado"
+            "totalCountTemplate": "${count} seleccionado"
         },
         "listbox": {
             "noRecordsTemplate": "No se encontraron registros",

--- a/src/fa.json
+++ b/src/fa.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "هیچ سابقه ای یافت نشد",
             "actionFailureTemplate": "درخواست انجام نشد",
-            "overflowCountTemplate": "+ $ {تعداد} موارد دیگر ..",
+            "overflowCountTemplate": "+${تعداد} موارد دیگر ..",
             "selectAllText": "انتخاب همه",
             "unSelectAllText": "همه را انتخاب کنید",
-            "totalCountTemplate": "$ {count} انتخاب شد"
+            "totalCountTemplate": "${count} انتخاب شد"
         },
         "drop-down-list": {
             "noRecordsTemplate": "هیچ سابقه ای یافت نشد",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "هیچ سابقه ای یافت نشد",
             "actionFailureTemplate": "درخواست انجام نشد",
-            "overflowCountTemplate": "+ $ {تعداد} موارد دیگر ..",
+            "overflowCountTemplate": "+${تعداد} موارد دیگر ..",
             "selectAllText": "انتخاب همه",
             "unSelectAllText": "همه را انتخاب کنید",
-            "totalCountTemplate": "$ {count} انتخاب شد"
+            "totalCountTemplate": "${count} انتخاب شد"
         },
         "listbox": {
             "noRecordsTemplate": "هیچ سابقه ای یافت نشد",

--- a/src/fi.json
+++ b/src/fi.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "Merkintöjä ei löydy",
             "actionFailureTemplate": "Pyyntö epäonnistui",
-            "overflowCountTemplate": "+ $ {count} lisää ..",
+            "overflowCountTemplate": "+${count} lisää ..",
             "selectAllText": "Valitse kaikki",
             "unSelectAllText": "Poista kaikki valinnat",
-            "totalCountTemplate": "$ {count} valittu"
+            "totalCountTemplate": "${count} valittu"
         },
         "drop-down-list": {
             "noRecordsTemplate": "Merkintöjä ei löydy",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "Merkintöjä ei löydy",
             "actionFailureTemplate": "Pyyntö epäonnistui",
-            "overflowCountTemplate": "+ $ {count} lisää ..",
+            "overflowCountTemplate": "+${count} lisää ..",
             "selectAllText": "Valitse kaikki",
             "unSelectAllText": "Poista kaikki valinnat",
-            "totalCountTemplate": "$ {count} valittu"
+            "totalCountTemplate": "${count} valittu"
         },
         "listbox": {
             "noRecordsTemplate": "Merkintöjä ei löydy",

--- a/src/fr.json
+++ b/src/fr.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "Aucun enregistrement trouvé",
             "actionFailureTemplate": "La demande a échoué",
-            "overflowCountTemplate": "+ $ {count} de plus ..",
+            "overflowCountTemplate": "+${count} de plus ..",
             "selectAllText": "Tout sélectionner",
             "unSelectAllText": "Tout déselectionner",
-            "totalCountTemplate": "$ {count} sélectionné"
+            "totalCountTemplate": "${count} sélectionné"
         },
         "drop-down-list": {
             "noRecordsTemplate": "Aucun enregistrement trouvé",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "Aucun enregistrement trouvé",
             "actionFailureTemplate": "La demande a échoué",
-            "overflowCountTemplate": "+ $ {count} de plus ..",
+            "overflowCountTemplate": "+${count} de plus ..",
             "selectAllText": "Tout sélectionner",
             "unSelectAllText": "Tout déselectionner",
-            "totalCountTemplate": "$ {count} sélectionné"
+            "totalCountTemplate": "${count} sélectionné"
         },
         "listbox": {
             "noRecordsTemplate": "Aucun enregistrement trouvé",

--- a/src/he.json
+++ b/src/he.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "לא נמצאו שיאים",
             "actionFailureTemplate": "הבקשה נכשלה",
-            "overflowCountTemplate": "+ $ {count} יותר ..",
+            "overflowCountTemplate": "+${count} יותר ..",
             "selectAllText": "בחר הכל",
             "unSelectAllText": "בטל את הבחירה בכולם",
-            "totalCountTemplate": "נבחרו $ {count}"
+            "totalCountTemplate": "נבחרו ${count}"
         },
         "drop-down-list": {
             "noRecordsTemplate": "לא נמצאו שיאים",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "לא נמצאו שיאים",
             "actionFailureTemplate": "הבקשה נכשלה",
-            "overflowCountTemplate": "+ $ {count} יותר ..",
+            "overflowCountTemplate": "+${count} יותר ..",
             "selectAllText": "בחר הכל",
             "unSelectAllText": "בטל את הבחירה בכולם",
-            "totalCountTemplate": "נבחרו $ {count}"
+            "totalCountTemplate": "נבחרו ${count}"
         },
         "listbox": {
             "noRecordsTemplate": "לא נמצאו שיאים",

--- a/src/hr.json
+++ b/src/hr.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "Nije pronađen niti jedan zapis",
             "actionFailureTemplate": "Zahtjev nije uspio",
-            "overflowCountTemplate": "+ $ {count} više ..",
+            "overflowCountTemplate": "+${count} više ..",
             "selectAllText": "Odaberi sve",
             "unSelectAllText": "Poništi odabir svih",
-            "totalCountTemplate": "Odabran je $ {count}"
+            "totalCountTemplate": "Odabran je ${count}"
         },
         "drop-down-list": {
             "noRecordsTemplate": "Nije pronađen niti jedan zapis",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "Nije pronađen niti jedan zapis",
             "actionFailureTemplate": "Zahtjev nije uspio",
-            "overflowCountTemplate": "+ $ {count} više ..",
+            "overflowCountTemplate": "+${count} više ..",
             "selectAllText": "Odaberi sve",
             "unSelectAllText": "Poništi odabir svih",
-            "totalCountTemplate": "Odabran je $ {count}"
+            "totalCountTemplate": "Odabran je ${count}"
         },
         "listbox": {
             "noRecordsTemplate": "Nije pronađen niti jedan zapis",

--- a/src/hu.json
+++ b/src/hu.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "Nincs találat",
             "actionFailureTemplate": "A kérés sikertelen",
-            "overflowCountTemplate": "+ $ {count} további ..",
+            "overflowCountTemplate": "+${count} további ..",
             "selectAllText": "Mindet kiválaszt",
             "unSelectAllText": "Minden kijelölés megszüntetése",
-            "totalCountTemplate": "$ {count} kiválasztva"
+            "totalCountTemplate": "${count} kiválasztva"
         },
         "drop-down-list": {
             "noRecordsTemplate": "Nincs találat",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "Nincs találat",
             "actionFailureTemplate": "A kérés sikertelen",
-            "overflowCountTemplate": "+ $ {count} további ..",
+            "overflowCountTemplate": "+${count} további ..",
             "selectAllText": "Mindet kiválaszt",
             "unSelectAllText": "Minden kijelölés megszüntetése",
-            "totalCountTemplate": "$ {count} kiválasztva"
+            "totalCountTemplate": "${count} kiválasztva"
         },
         "listbox": {
             "noRecordsTemplate": "Nincs találat",

--- a/src/id.json
+++ b/src/id.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "Tidak Ditemukan Catatan",
             "actionFailureTemplate": "Permintaan Gagal",
-            "overflowCountTemplate": "+ $ {count} lagi ..",
+            "overflowCountTemplate": "+${count} lagi ..",
             "selectAllText": "Pilih Semua",
             "unSelectAllText": "Batalkan Semua Pilihan",
-            "totalCountTemplate": "$ {count} dipilih"
+            "totalCountTemplate": "${count} dipilih"
         },
         "drop-down-list": {
             "noRecordsTemplate": "Tidak Ditemukan Catatan",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "Tidak Ditemukan Catatan",
             "actionFailureTemplate": "Permintaan Gagal",
-            "overflowCountTemplate": "+ $ {count} lagi ..",
+            "overflowCountTemplate": "+${count} lagi ..",
             "selectAllText": "Pilih Semua",
             "unSelectAllText": "Batalkan Semua Pilihan",
-            "totalCountTemplate": "$ {count} dipilih"
+            "totalCountTemplate": "${count} dipilih"
         },
         "listbox": {
             "noRecordsTemplate": "Tidak Ditemukan Catatan",

--- a/src/it.json
+++ b/src/it.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "Nessun record trovato",
             "actionFailureTemplate": "La richiesta non è riuscita",
-            "overflowCountTemplate": "+ $ {count} di più ..",
+            "overflowCountTemplate": "+${count} di più ..",
             "selectAllText": "Seleziona tutto",
             "unSelectAllText": "Deseleziona tutto",
-            "totalCountTemplate": "$ {count} selezionato"
+            "totalCountTemplate": "${count} selezionato"
         },
         "drop-down-list": {
             "noRecordsTemplate": "Nessun record trovato",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "Nessun record trovato",
             "actionFailureTemplate": "La richiesta non è riuscita",
-            "overflowCountTemplate": "+ $ {count} di più ..",
+            "overflowCountTemplate": "+${count} di più ..",
             "selectAllText": "Seleziona tutto",
             "unSelectAllText": "Deseleziona tutto",
-            "totalCountTemplate": "$ {count} selezionato"
+            "totalCountTemplate": "${count} selezionato"
         },
         "listbox": {
             "noRecordsTemplate": "Nessun record trovato",

--- a/src/ja.json
+++ b/src/ja.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "レコードが見つかりません",
             "actionFailureTemplate": "リクエストに失敗しました",
-            "overflowCountTemplate": "+ $ {count}以上..",
+            "overflowCountTemplate": "+${count}以上..",
             "selectAllText": "すべて選択",
             "unSelectAllText": "すべて選択解除",
-            "totalCountTemplate": "$ {count}を選択しました"
+            "totalCountTemplate": "${count}を選択しました"
         },
         "drop-down-list": {
             "noRecordsTemplate": "レコードが見つかりません",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "レコードが見つかりません",
             "actionFailureTemplate": "リクエストに失敗しました",
-            "overflowCountTemplate": "+ $ {count}以上..",
+            "overflowCountTemplate": "+${count}以上..",
             "selectAllText": "すべて選択",
             "unSelectAllText": "すべて選択解除",
-            "totalCountTemplate": "$ {count}を選択しました"
+            "totalCountTemplate": "${count}を選択しました"
         },
         "listbox": {
             "noRecordsTemplate": "レコードが見つかりません",

--- a/src/ko.json
+++ b/src/ko.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "기록 없음",
             "actionFailureTemplate": "요청 실패",
-            "overflowCountTemplate": "+ $ {count} 개 더 ..",
+            "overflowCountTemplate": "+${count} 개 더 ..",
             "selectAllText": "모두 선택",
             "unSelectAllText": "모두 선택 해제",
-            "totalCountTemplate": "선택된 $ {count}"
+            "totalCountTemplate": "선택된 ${count}"
         },
         "drop-down-list": {
             "noRecordsTemplate": "기록 없음",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "기록 없음",
             "actionFailureTemplate": "요청 실패",
-            "overflowCountTemplate": "+ $ {count} 개 더 ..",
+            "overflowCountTemplate": "+${count} 개 더 ..",
             "selectAllText": "모두 선택",
             "unSelectAllText": "모두 선택 해제",
-            "totalCountTemplate": "선택된 $ {count}"
+            "totalCountTemplate": "선택된 ${count}"
         },
         "listbox": {
             "noRecordsTemplate": "기록 없음",

--- a/src/ms.json
+++ b/src/ms.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "기록 없음",
             "actionFailureTemplate": "요청 실패",
-            "overflowCountTemplate": "+ $ {count} 개 더 ..",
+            "overflowCountTemplate": "+${count} 개 더 ..",
             "selectAllText": "모두 선택",
             "unSelectAllText": "모두 선택 해제",
-            "totalCountTemplate": "선택된 $ {count}"
+            "totalCountTemplate": "선택된 ${count}"
         },
         "drop-down-list": {
             "noRecordsTemplate": "기록 없음",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "기록 없음",
             "actionFailureTemplate": "요청 실패",
-            "overflowCountTemplate": "+ $ {count} 개 더 ..",
+            "overflowCountTemplate": "+${count} 개 더 ..",
             "selectAllText": "모두 선택",
             "unSelectAllText": "모두 선택 해제",
-            "totalCountTemplate": "선택된 $ {count}"
+            "totalCountTemplate": "선택된 ${count}"
         },
         "listbox": {
             "noRecordsTemplate": "기록 없음",

--- a/src/nb.json
+++ b/src/nb.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "Ingen opptak funnet",
             "actionFailureTemplate": "Forespørselen mislyktes",
-            "overflowCountTemplate": "+ $ {count} mer ..",
+            "overflowCountTemplate": "+${count} mer ..",
             "selectAllText": "Velg alle",
             "unSelectAllText": "Avmarker alt",
-            "totalCountTemplate": "$ {count} valgt"
+            "totalCountTemplate": "${count} valgt"
         },
         "drop-down-list": {
             "noRecordsTemplate": "Ingen opptak funnet",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "Ingen opptak funnet",
             "actionFailureTemplate": "Forespørselen mislyktes",
-            "overflowCountTemplate": "+ $ {count} mer ..",
+            "overflowCountTemplate": "+${count} mer ..",
             "selectAllText": "Velg alle",
             "unSelectAllText": "Avmarker alt",
-            "totalCountTemplate": "$ {count} valgt"
+            "totalCountTemplate": "${count} valgt"
         },
         "listbox": {
             "noRecordsTemplate": "Ingen opptak funnet",

--- a/src/nl.json
+++ b/src/nl.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "Geen verslagen gevonden",
             "actionFailureTemplate": "Het verzoek is mislukt",
-            "overflowCountTemplate": "+ $ {count} meer ..",
+            "overflowCountTemplate": "+${count} meer ..",
             "selectAllText": "Selecteer alles",
             "unSelectAllText": "Deselecteer alles",
-            "totalCountTemplate": "$ {count} geselecteerd"
+            "totalCountTemplate": "${count} geselecteerd"
         },
         "drop-down-list": {
             "noRecordsTemplate": "Geen verslagen gevonden",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "Geen verslagen gevonden",
             "actionFailureTemplate": "Het verzoek is mislukt",
-            "overflowCountTemplate": "+ $ {count} meer ..",
+            "overflowCountTemplate": "+${count} meer ..",
             "selectAllText": "Selecteer alles",
             "unSelectAllText": "Deselecteer alles",
-            "totalCountTemplate": "$ {count} geselecteerd"
+            "totalCountTemplate": "${count} geselecteerd"
         },
         "listbox": {
             "noRecordsTemplate": "Geen verslagen gevonden",

--- a/src/pl.json
+++ b/src/pl.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "Nic nie znaleziono",
             "actionFailureTemplate": "Żądanie nie powiodło się",
-            "overflowCountTemplate": "+ $ {count} więcej ..",
+            "overflowCountTemplate": "+${count} więcej ..",
             "selectAllText": "Zaznacz wszystko",
             "unSelectAllText": "Odznacz wszystko",
-            "totalCountTemplate": "Wybrano $ {count}"
+            "totalCountTemplate": "Wybrano ${count}"
         },
         "drop-down-list": {
             "noRecordsTemplate": "Nic nie znaleziono",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "Nic nie znaleziono",
             "actionFailureTemplate": "Żądanie nie powiodło się",
-            "overflowCountTemplate": "+ $ {count} więcej ..",
+            "overflowCountTemplate": "+${count} więcej ..",
             "selectAllText": "Zaznacz wszystko",
             "unSelectAllText": "Odznacz wszystko",
-            "totalCountTemplate": "Wybrano $ {count}"
+            "totalCountTemplate": "Wybrano ${count}"
         },
         "listbox": {
             "noRecordsTemplate": "Nic nie znaleziono",

--- a/src/pt.json
+++ b/src/pt.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "Nenhum registro foi encontrado",
             "actionFailureTemplate": "A solicitação falhou",
-            "overflowCountTemplate": "+ $ {count} mais ..",
+            "overflowCountTemplate": "+${count} mais ..",
             "selectAllText": "Selecionar tudo",
             "unSelectAllText": "Desmarque todos",
-            "totalCountTemplate": "$ {count} selecionado"
+            "totalCountTemplate": "${count} selecionado"
         },
         "drop-down-list": {
             "noRecordsTemplate": "Nenhum registro foi encontrado",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "Nenhum registro foi encontrado",
             "actionFailureTemplate": "A solicitação falhou",
-            "overflowCountTemplate": "+ $ {count} mais ..",
+            "overflowCountTemplate": "+${count} mais ..",
             "selectAllText": "Selecionar tudo",
             "unSelectAllText": "Desmarque todos",
-            "totalCountTemplate": "$ {count} selecionado"
+            "totalCountTemplate": "${count} selecionado"
         },
         "listbox": {
             "noRecordsTemplate": "Nenhum registro foi encontrado",

--- a/src/ro.json
+++ b/src/ro.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "Nu au fost găsite",
             "actionFailureTemplate": "Solicitarea a eșuat",
-            "overflowCountTemplate": "+ $ {număr} mai mult ..",
+            "overflowCountTemplate": "+${număr} mai mult ..",
             "selectAllText": "Selectează tot",
             "unSelectAllText": "Deselectează tot",
-            "totalCountTemplate": "$ {număr} selectat"
+            "totalCountTemplate": "${număr} selectat"
         },
         "drop-down-list": {
             "noRecordsTemplate": "Nu au fost găsite",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "Nu au fost găsite",
             "actionFailureTemplate": "Solicitarea a eșuat",
-            "overflowCountTemplate": "+ $ {număr} mai mult ..",
+            "overflowCountTemplate": "+${număr} mai mult ..",
             "selectAllText": "Selectează tot",
             "unSelectAllText": "Deselectează tot",
-            "totalCountTemplate": "$ {număr} selectat"
+            "totalCountTemplate": "${număr} selectat"
         },
         "listbox": {
             "noRecordsTemplate": "Nu au fost găsite",

--- a/src/ru.json
+++ b/src/ru.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "Записей не найдено",
             "actionFailureTemplate": "Ошибка запроса",
-            "overflowCountTemplate": "+ $ {count} больше ..",
+            "overflowCountTemplate": "+${count} больше ..",
             "selectAllText": "Выбрать все",
             "unSelectAllText": "Снять все",
-            "totalCountTemplate": "$ {count} выбран"
+            "totalCountTemplate": "${count} выбран"
         },
         "drop-down-list": {
             "noRecordsTemplate": "Записей не найдено",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "Записей не найдено",
             "actionFailureTemplate": "Ошибка запроса",
-            "overflowCountTemplate": "+ $ {count} больше ..",
+            "overflowCountTemplate": "+${count} больше ..",
             "selectAllText": "Выбрать все",
             "unSelectAllText": "Снять все",
-            "totalCountTemplate": "$ {count} выбран"
+            "totalCountTemplate": "${count} выбран"
         },
         "listbox": {
             "noRecordsTemplate": "Записей не найдено",

--- a/src/sk.json
+++ b/src/sk.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "Nenašli sa žiadne záznamy",
             "actionFailureTemplate": "Žiadosť zlyhala",
-            "overflowCountTemplate": "+ $ {count} viac ..",
+            "overflowCountTemplate": "+${count} viac ..",
             "selectAllText": "Vybrať všetko",
             "unSelectAllText": "Odznačiť všetko",
-            "totalCountTemplate": "Bol vybratý $ {count}"
+            "totalCountTemplate": "Bol vybratý ${count}"
         },
         "drop-down-list": {
             "noRecordsTemplate": "Nenašli sa žiadne záznamy",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "Nenašli sa žiadne záznamy",
             "actionFailureTemplate": "Žiadosť zlyhala",
-            "overflowCountTemplate": "+ $ {count} viac ..",
+            "overflowCountTemplate": "+${count} viac ..",
             "selectAllText": "Vybrať všetko",
             "unSelectAllText": "Odznačiť všetko",
-            "totalCountTemplate": "Bol vybratý $ {count}"
+            "totalCountTemplate": "Bol vybratý ${count}"
         },
         "listbox": {
             "noRecordsTemplate": "Nenašli sa žiadne záznamy",

--- a/src/sv.json
+++ b/src/sv.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "Inga uppgifter funna",
             "actionFailureTemplate": "Begäran misslyckades",
-            "overflowCountTemplate": "+ $ {count} mer ..",
+            "overflowCountTemplate": "+${count} mer ..",
             "selectAllText": "Välj alla",
             "unSelectAllText": "Avmarkera alla",
-            "totalCountTemplate": "$ {count} vald"
+            "totalCountTemplate": "${count} vald"
         },
         "drop-down-list": {
             "noRecordsTemplate": "Inga uppgifter funna",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "Inga uppgifter funna",
             "actionFailureTemplate": "Begäran misslyckades",
-            "overflowCountTemplate": "+ $ {count} mer ..",
+            "overflowCountTemplate": "+${count} mer ..",
             "selectAllText": "Välj alla",
             "unSelectAllText": "Avmarkera alla",
-            "totalCountTemplate": "$ {count} vald"
+            "totalCountTemplate": "${count} vald"
         },
         "listbox": {
             "noRecordsTemplate": "Inga uppgifter funna",

--- a/src/th.json
+++ b/src/th.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "ไม่พบบันทึก",
             "actionFailureTemplate": "การร้องขอล้มเหลว",
-            "overflowCountTemplate": "+ $ {จำนวน} อีกมาก ..",
+            "overflowCountTemplate": "+${จำนวน} อีกมาก ..",
             "selectAllText": "เลือกทั้งหมด",
             "unSelectAllText": "ไม่เลือกทั้งหมด",
-            "totalCountTemplate": "เลือก $ {count}"
+            "totalCountTemplate": "เลือก ${count}"
         },
         "drop-down-list": {
             "noRecordsTemplate": "ไม่พบบันทึก",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "ไม่พบบันทึก",
             "actionFailureTemplate": "การร้องขอล้มเหลว",
-            "overflowCountTemplate": "+ $ {จำนวน} อีกมาก ..",
+            "overflowCountTemplate": "+${จำนวน} อีกมาก ..",
             "selectAllText": "เลือกทั้งหมด",
             "unSelectAllText": "ไม่เลือกทั้งหมด",
-            "totalCountTemplate": "เลือก $ {count}"
+            "totalCountTemplate": "เลือก ${count}"
         },
         "listbox": {
             "noRecordsTemplate": "ไม่พบบันทึก",

--- a/src/tr.json
+++ b/src/tr.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "Kayıt bulunamadı",
             "actionFailureTemplate": "İstek Başarısız Oldu",
-            "overflowCountTemplate": "+ $ {count} tane daha ..",
+            "overflowCountTemplate": "+${count} tane daha ..",
             "selectAllText": "Hepsini seç",
             "unSelectAllText": "Tümünün Seçimini Kaldır",
-            "totalCountTemplate": "$ {count} tane seçildi"
+            "totalCountTemplate": "${count} tane seçildi"
         },
         "drop-down-list": {
             "noRecordsTemplate": "Kayıt bulunamadı",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "Kayıt bulunamadı",
             "actionFailureTemplate": "İstek Başarısız Oldu",
-            "overflowCountTemplate": "+ $ {count} tane daha ..",
+            "overflowCountTemplate": "+${count} tane daha ..",
             "selectAllText": "Hepsini seç",
             "unSelectAllText": "Tümünün Seçimini Kaldır",
-            "totalCountTemplate": "$ {count} tane seçildi"
+            "totalCountTemplate": "${count} tane seçildi"
         },
         "listbox": {
             "noRecordsTemplate": "Kayıt bulunamadı",

--- a/src/vi.json
+++ b/src/vi.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "Không có dữ liệu được tìm thấy",
             "actionFailureTemplate": "Yêu cầu thất bại",
-            "overflowCountTemplate": "+ $ {tính} thêm ..",
+            "overflowCountTemplate": "+${tính} thêm ..",
             "selectAllText": "Chọn tất cả",
             "unSelectAllText": "Bỏ chọn tất cả",
-            "totalCountTemplate": "$ {tính} đã chọn"
+            "totalCountTemplate": "${tính} đã chọn"
         },
         "drop-down-list": {
             "noRecordsTemplate": "Không có dữ liệu được tìm thấy",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "Không có dữ liệu được tìm thấy",
             "actionFailureTemplate": "Yêu cầu thất bại",
-            "overflowCountTemplate": "+ $ {tính} thêm ..",
+            "overflowCountTemplate": "+${tính} thêm ..",
             "selectAllText": "Chọn tất cả",
             "unSelectAllText": "Bỏ chọn tất cả",
-            "totalCountTemplate": "$ {tính} đã chọn"
+            "totalCountTemplate": "${tính} đã chọn"
         },
         "listbox": {
             "noRecordsTemplate": "Không có dữ liệu được tìm thấy",

--- a/src/zh.json
+++ b/src/zh.json
@@ -923,10 +923,10 @@
         "dropdowns": {
             "noRecordsTemplate": "沒有找到記錄",
             "actionFailureTemplate": "請求失敗",
-            "overflowCountTemplate": "+ $ {count}更多..",
+            "overflowCountTemplate": "+${count}更多..",
             "selectAllText": "全選",
             "unSelectAllText": "全部取消選擇",
-            "totalCountTemplate": "已選擇$ {count}個"
+            "totalCountTemplate": "已選擇${count}個"
         },
         "drop-down-list": {
             "noRecordsTemplate": "沒有找到記錄",
@@ -943,10 +943,10 @@
         "multi-select": {
             "noRecordsTemplate": "沒有找到記錄",
             "actionFailureTemplate": "請求失敗",
-            "overflowCountTemplate": "+ $ {count}更多..",
+            "overflowCountTemplate": "+${count}更多..",
             "selectAllText": "全選",
             "unSelectAllText": "全部取消選擇",
-            "totalCountTemplate": "已選擇$ {count}個"
+            "totalCountTemplate": "已選擇${count}個"
         },
         "listbox": {
             "noRecordsTemplate": "沒有找到記錄",


### PR DESCRIPTION
The space contained in the variable was considered as string. So it returns with the '$ {count}' sign. Modified all locale text file by removing the space.