### PR TITLE
Fixed typo in pager.totalItemInfo

### DIFF
--- a/src/de.json
+++ b/src/de.json
@@ -1817,7 +1817,7 @@
             "pagerDropDown": "Datensätze pro Seite",
             "pagerAllDropDown": "Datensätze",
             "All": "Alle",
-            "totalItemInfo": "({0} Datensätz)"
+            "totalItemInfo": "({0} Datensätze)"
         },
         "calendar": {
             "today": "Heute"


### PR DESCRIPTION
The correct term for multiple data records is "Datensätze" in German. I have added the missing e in the end to fix this grammatical error.