### PR TITLE
bug(EJ2-68684):Column dialog is not read properly by JAWS screen reader

### DIFF
--- a/src/ar-AE.json
+++ b/src/ar-AE.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "مربع حوار قائمة التصفية",
             "ExcelFilterDialogARIA": "مربع حوار مرشح Excel",
             "DialogEditARIA": "مربع حوار التحرير",
-            "ColumnChooserDialogARIA": "مربع حوار منتقي الأعمدة",
+            "ColumnChooserDialogARIA": "منتقي الأعمدة",
             "ColumnMenuDialogARIA": "مربع حوار قائمة العمود",
             "CustomFilterDialogARIA": "مربع حوار عامل التصفية المخصص",
             "SortAtoZ": "فرز من الألف إلى الياء",

--- a/src/ar.json
+++ b/src/ar.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "مربع حوار قائمة التصفية",
             "ExcelFilterDialogARIA": "مربع حوار مرشح Excel",
             "DialogEditARIA": "مربع حوار التحرير",
-            "ColumnChooserDialogARIA": "مربع حوار منتقي الأعمدة",
+            "ColumnChooserDialogARIA": "منتقي الأعمدة",
             "ColumnMenuDialogARIA": "مربع حوار قائمة العمود",
             "CustomFilterDialogARIA": "مربع حوار عامل التصفية المخصص",
             "SortAtoZ": "فرز من الألف إلى الياء",

--- a/src/cs.json
+++ b/src/cs.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Dialogové okno nabídky Filtr",
             "ExcelFilterDialogARIA": "Dialogové okno filtru aplikace Excel",
             "DialogEditARIA": "Dialogové okno Upravit",
-            "ColumnChooserDialogARIA": "Dialogové okno pro výběr sloupců",
+            "ColumnChooserDialogARIA": "Výběr sloupců",
             "ColumnMenuDialogARIA": "Dialogové okno nabídky sloupce",
             "CustomFilterDialogARIA": "Dialogové okno vlastního filtru",
             "SortAtoZ": "Seřadit od A do Z",

--- a/src/da.json
+++ b/src/da.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Filtermenudialog",
             "ExcelFilterDialogARIA": "Excel filter dialog",
             "DialogEditARIA": "Redigeringsdialog",
-            "ColumnChooserDialogARIA": "Kolonnevælgerdialog",
+            "ColumnChooserDialogARIA": "Kolonnevælger",
             "ColumnMenuDialogARIA": "Kolonnemenudialog",
             "CustomFilterDialogARIA": "Tilpasset filterdialog",
             "SortAtoZ": "Sorter A til Z",

--- a/src/de.json
+++ b/src/de.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Menüdialog filtern",
             "ExcelFilterDialogARIA": "Excel-Filterdialog",
             "DialogEditARIA": "Dialog bearbeiten",
-            "ColumnChooserDialogARIA": "Spaltenauswahldialog",
+            "ColumnChooserDialogARIA": "Spaltenauswahl",
             "ColumnMenuDialogARIA": "Spaltenmenüdialog",
             "CustomFilterDialogARIA": "Benutzerdefinierter Filterdialog",
             "SortAtoZ": "Sortiere von A bis Z",

--- a/src/en-GB.json
+++ b/src/en-GB.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Filter menu dialog",
             "ExcelFilterDialogARIA": "Excel filter dialog",
             "DialogEditARIA": "Edit dialog",
-            "ColumnChooserDialogARIA": "Column chooser dialog",
+            "ColumnChooserDialogARIA": "Column chooser",
             "ColumnMenuDialogARIA": "Column menu dialog",
             "CustomFilterDialogARIA": "Custom filter dialog",
             "SortAtoZ": "Sort A to Z",

--- a/src/en-US.json
+++ b/src/en-US.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Filter menu dialog",
             "ExcelFilterDialogARIA": "Excel filter dialog",
             "DialogEditARIA": "Edit dialog",
-            "ColumnChooserDialogARIA": "Column chooser dialog",
+            "ColumnChooserDialogARIA": "Column chooser",
             "ColumnMenuDialogARIA": "Column menu dialog",
             "CustomFilterDialogARIA": "Custom filter dialog",
             "SortAtoZ": "Sort A to Z",

--- a/src/es.json
+++ b/src/es.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Cuadro de diálogo del menú de filtro",
             "ExcelFilterDialogARIA": "Diálogo de filtro de Excel",
             "DialogEditARIA": "Cuadro de diálogo Editar",
-            "ColumnChooserDialogARIA": "Cuadro de diálogo del selector de columnas",
+            "ColumnChooserDialogARIA": "Selector de columnas",
             "ColumnMenuDialogARIA": "Diálogo de menú de columna",
             "CustomFilterDialogARIA": "Diálogo de filtro personalizado",
             "SortAtoZ": "Ordenar de la A a la Z",

--- a/src/fa.json
+++ b/src/fa.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "گفتگوی منوی فیلتر",
             "ExcelFilterDialogARIA": "گفتگوی فیلتر اکسل",
             "DialogEditARIA": "ویرایش گفتگو",
-            "ColumnChooserDialogARIA": "گفتگوی انتخابگر ستون",
+            "ColumnChooserDialogARIA": "انتخابگر ستون",
             "ColumnMenuDialogARIA": "گفتگوی منوی ستونی",
             "CustomFilterDialogARIA": "گفتگوی فیلتر سفارشی",
             "SortAtoZ": "مرتب سازی A تا Z",

--- a/src/fi.json
+++ b/src/fi.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Suodatinvalikon valintaikkuna",
             "ExcelFilterDialogARIA": "Excelin suodatinvalintaikkuna",
             "DialogEditARIA": "Muokkaa valintaikkunaa",
-            "ColumnChooserDialogARIA": "Sarakkeen valintaikkuna",
+            "ColumnChooserDialogARIA": "Sarakkeen valitsin",
             "ColumnMenuDialogARIA": "Sarakevalikon valintaikkuna",
             "CustomFilterDialogARIA": "Mukautetun suodattimen valintaikkuna",
             "SortAtoZ": "Lajittele A–Z",

--- a/src/fr.json
+++ b/src/fr.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Boîte de dialogue du menu Filtre",
             "ExcelFilterDialogARIA": "Boîte de dialogue de filtre Excel",
             "DialogEditARIA": "Boîte de dialogue Modifier",
-            "ColumnChooserDialogARIA": "Boîte de dialogue de sélection de colonne",
+            "ColumnChooserDialogARIA": "Sélecteur de colonne",
             "ColumnMenuDialogARIA": "Boîte de dialogue du menu des colonnes",
             "CustomFilterDialogARIA": "Boîte de dialogue Filtre personnalisé",
             "SortAtoZ": "Trier de A à Z",

--- a/src/he.json
+++ b/src/he.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "דו-שיח של תפריט סינון",
             "ExcelFilterDialogARIA": "דו-שיח מסנן Excel",
             "DialogEditARIA": "תיבת דו-שיח עריכה",
-            "ColumnChooserDialogARIA": "דו-שיח של בוחר עמודות",
+            "ColumnChooserDialogARIA": "בוחר עמודות",
             "ColumnMenuDialogARIA": "דו-שיח של תפריט עמודות",
             "CustomFilterDialogARIA": "דו-שיח מסנן מותאם אישית",
             "SortAtoZ": "מיין א' עד ת'",

--- a/src/hr.json
+++ b/src/hr.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Dijalog izbornika Filter",
             "ExcelFilterDialogARIA": "Dijalog filtra u Excelu",
             "DialogEditARIA": "Dijalog za uređivanje",
-            "ColumnChooserDialogARIA": "Dijalog za odabir stupaca",
+            "ColumnChooserDialogARIA": "Birač stupaca",
             "ColumnMenuDialogARIA": "Dijalog izbornika stupca",
             "CustomFilterDialogARIA": "Dijalog prilagođenog filtra",
             "SortAtoZ": "Poredaj od A do Ž",

--- a/src/hu.json
+++ b/src/hu.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Szűrő menü párbeszédpanel",
             "ExcelFilterDialogARIA": "Excel szűrő párbeszédpanel",
             "DialogEditARIA": "Szerkesztés párbeszédpanel",
-            "ColumnChooserDialogARIA": "Oszlopválasztó párbeszédpanel",
+            "ColumnChooserDialogARIA": "Oszlopválasztó",
             "ColumnMenuDialogARIA": "Oszlop menü párbeszédpanel",
             "CustomFilterDialogARIA": "Egyéni szűrő párbeszédpanel",
             "SortAtoZ": "Rendezés A-tól Z-ig",

--- a/src/id.json
+++ b/src/id.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Dialog menu filter",
             "ExcelFilterDialogARIA": "Dialog filter Excel",
             "DialogEditARIA": "Edit dialog",
-            "ColumnChooserDialogARIA": "Dialog pemilih kolom",
+            "ColumnChooserDialogARIA": "Pemilih kolom",
             "ColumnMenuDialogARIA": "Dialog menu kolom",
             "CustomFilterDialogARIA": "Dialog filter khusus",
             "SortAtoZ": "Urutkan A sampai Z",

--- a/src/it.json
+++ b/src/it.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Finestra di dialogo del menu Filtra",
             "ExcelFilterDialogARIA": "Finestra di dialogo del filtro di Excel",
             "DialogEditARIA": "Finestra di dialogo Modifica",
-            "ColumnChooserDialogARIA": "Finestra di dialogo per la selezione delle colonne",
+            "ColumnChooserDialogARIA": "Selettore di colonne",
             "ColumnMenuDialogARIA": "Finestra di dialogo del menu delle colonne",
             "CustomFilterDialogARIA": "Finestra di dialogo filtro personalizzato",
             "SortAtoZ": "Ordina dalla A alla Z",

--- a/src/ja.json
+++ b/src/ja.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "フィルタメニューダイアログ",
             "ExcelFilterDialogARIA": "Excelフィルターダイアログ",
             "DialogEditARIA": "編集ダイアログ",
-            "ColumnChooserDialogARIA": "列選択ダイアログ",
+            "ColumnChooserDialogARIA": "列の選択",
             "ColumnMenuDialogARIA": "列メニューダイアログ",
             "CustomFilterDialogARIA": "カスタムフィルターダイアログ",
             "SortAtoZ": "AからZに並べ替え",

--- a/src/ko.json
+++ b/src/ko.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "필터 메뉴 대화 상자",
             "ExcelFilterDialogARIA": "Excel 필터 대화 상자",
             "DialogEditARIA": "편집 대화 상자",
-            "ColumnChooserDialogARIA": "열 선택기 대화 상자",
+            "ColumnChooserDialogARIA": "열 선택기",
             "ColumnMenuDialogARIA": "열 메뉴 대화 상자",
             "CustomFilterDialogARIA": "사용자 정의 필터 대화 상자",
             "SortAtoZ": "A부터 Z까지 정렬",

--- a/src/ms.json
+++ b/src/ms.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Dialog menu penapis",
             "ExcelFilterDialogARIA": "Dialog penapis Excel",
             "DialogEditARIA": "Edit dialog",
-            "ColumnChooserDialogARIA": "Dialog pemilih lajur",
+            "ColumnChooserDialogARIA": "Pemilih kolom",
             "ColumnMenuDialogARIA": "Dialog menu lajur",
             "CustomFilterDialogARIA": "Dialog penapis tersuai",
             "SortAtoZ": "Isih A hingga Z",

--- a/src/nb.json
+++ b/src/nb.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Filtermenydialog",
             "ExcelFilterDialogARIA": "Excel-filterdialog",
             "DialogEditARIA": "Rediger dialog",
-            "ColumnChooserDialogARIA": "Kolonnevelgerdialog",
+            "ColumnChooserDialogARIA": "Kolonnevelger",
             "ColumnMenuDialogARIA": "Kolonnemenydialog",
             "CustomFilterDialogARIA": "Egendefinert filterdialog",
             "SortAtoZ": "Sorter A til Z",

--- a/src/nl.json
+++ b/src/nl.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Dialoogvenster Filtermenu",
             "ExcelFilterDialogARIA": "Dialoogvenster Excel-filter",
             "DialogEditARIA": "Dialoogvenster bewerken",
-            "ColumnChooserDialogARIA": "Dialoogvenster Kolomkiezer",
+            "ColumnChooserDialogARIA": "Kolomkiezer",
             "ColumnMenuDialogARIA": "Dialoogvenster Kolommenu",
             "CustomFilterDialogARIA": "Dialoogvenster Aangepast filter",
             "SortAtoZ": "Sorteer A tot Z",

--- a/src/pl.json
+++ b/src/pl.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Okno dialogowe menu filtrów",
             "ExcelFilterDialogARIA": "Okno dialogowe filtra Excel",
             "DialogEditARIA": "Edytuj okno dialogowe",
-            "ColumnChooserDialogARIA": "Okno wyboru kolumny",
+            "ColumnChooserDialogARIA": "Selektor kolumn",
             "ColumnMenuDialogARIA": "Okno dialogowe menu kolumny",
             "CustomFilterDialogARIA": "Okno dialogowe filtra niestandardowego",
             "SortAtoZ": "Sortuj od A do Z",

--- a/src/pt-BR.json
+++ b/src/pt-BR.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Caixa de diálogo do menu de filtro",
             "ExcelFilterDialogARIA": "Caixa de diálogo de filtro do Excel",
             "DialogEditARIA": "Caixa de diálogo Editar",
-            "ColumnChooserDialogARIA": "Caixa de diálogo do seletor de coluna",
+            "ColumnChooserDialogARIA": "Seletor de coluna",
             "ColumnMenuDialogARIA": "Caixa de diálogo do menu da coluna",
             "CustomFilterDialogARIA": "Caixa de diálogo de filtro personalizado",
             "SortAtoZ": "Ordenar de A a Z",

--- a/src/pt.json
+++ b/src/pt.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Caixa de diálogo do menu de filtro",
             "ExcelFilterDialogARIA": "Caixa de diálogo de filtro do Excel",
             "DialogEditARIA": "Caixa de diálogo Editar",
-            "ColumnChooserDialogARIA": "Caixa de diálogo do seletor de coluna",
+            "ColumnChooserDialogARIA": "Seletor de coluna",
             "ColumnMenuDialogARIA": "Caixa de diálogo do menu da coluna",
             "CustomFilterDialogARIA": "Caixa de diálogo de filtro personalizado",
             "SortAtoZ": "Ordenar de A a Z",

--- a/src/ro.json
+++ b/src/ro.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Dialog de meniu Filtrare",
             "ExcelFilterDialogARIA": "Dialog de filtru Excel",
             "DialogEditARIA": "dialog Editare",
-            "ColumnChooserDialogARIA": "Dialog de selectare a coloanelor",
+            "ColumnChooserDialogARIA": "Selector de coloane",
             "ColumnMenuDialogARIA": "Dialog meniu coloană",
             "CustomFilterDialogARIA": "Dialog de filtru personalizat",
             "SortAtoZ": "Sortați de la A la Z",

--- a/src/ru.json
+++ b/src/ru.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Диалоговое окно меню фильтра",
             "ExcelFilterDialogARIA": "Диалоговое окно фильтра Excel",
             "DialogEditARIA": "Диалоговое окно редактирования",
-            "ColumnChooserDialogARIA": "Диалоговое окно выбора столбца",
+            "ColumnChooserDialogARIA": "Выбор столбца",
             "ColumnMenuDialogARIA": "Диалоговое окно меню столбца",
             "CustomFilterDialogARIA": "Диалоговое окно пользовательского фильтра",
             "SortAtoZ": "Сортировать от А до Я",

--- a/src/sk.json
+++ b/src/sk.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Dialógové okno ponuky filtra",
             "ExcelFilterDialogARIA": "Dialógové okno filtra programu Excel",
             "DialogEditARIA": "Dialógové okno Upraviť",
-            "ColumnChooserDialogARIA": "Dialógové okno výberu stĺpcov",
+            "ColumnChooserDialogARIA": "Výber stĺpcov",
             "ColumnMenuDialogARIA": "Dialógové okno ponuky stĺpca",
             "CustomFilterDialogARIA": "Dialógové okno vlastného filtra",
             "SortAtoZ": "Zoradiť od A po Z",

--- a/src/sv.json
+++ b/src/sv.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Filtermenydialog",
             "ExcelFilterDialogARIA": "Excel-filterdialog",
             "DialogEditARIA": "Redigera dialog",
-            "ColumnChooserDialogARIA": "Dialogrutan för kolumnväljare",
+            "ColumnChooserDialogARIA": "Kolumnväljare",
             "ColumnMenuDialogARIA": "Kolumnmenydialog",
             "CustomFilterDialogARIA": "Dialogrutan för anpassat filter",
             "SortAtoZ": "Sortera A till Ö",

--- a/src/th.json
+++ b/src/th.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "กล่องโต้ตอบเมนูตัวกรอง",
             "ExcelFilterDialogARIA": "กล่องโต้ตอบตัวกรอง Excel",
             "DialogEditARIA": "แก้ไขกล่องโต้ตอบ",
-            "ColumnChooserDialogARIA": "กล่องโต้ตอบตัวเลือกคอลัมน์",
+            "ColumnChooserDialogARIA": "ตัวเลือกคอลัมน์",
             "ColumnMenuDialogARIA": "กล่องโต้ตอบเมนูคอลัมน์",
             "CustomFilterDialogARIA": "กล่องโต้ตอบตัวกรองแบบกำหนดเอง",
             "SortAtoZ": "เรียง A ถึง Z",

--- a/src/tr.json
+++ b/src/tr.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Filtre menüsü iletişim kutusu",
             "ExcelFilterDialogARIA": "Excel filtre iletişim kutusu",
             "DialogEditARIA": "Düzenle iletişim kutusu",
-            "ColumnChooserDialogARIA": "Sütun seçici iletişim kutusu",
+            "ColumnChooserDialogARIA": "Sütun seçici",
             "ColumnMenuDialogARIA": "Sütun menüsü iletişim kutusu",
             "CustomFilterDialogARIA": "Özel filtre iletişim kutusu",
             "SortAtoZ": "A'dan Z'ye Sırala",

--- a/src/vi.json
+++ b/src/vi.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "Hộp thoại menu bộ lọc",
             "ExcelFilterDialogARIA": "Hộp thoại bộ lọc Excel",
             "DialogEditARIA": "Chỉnh sửa hộp thoại",
-            "ColumnChooserDialogARIA": "Hộp thoại chọn cột",
+            "ColumnChooserDialogARIA": "bộ chọn cột",
             "ColumnMenuDialogARIA": "Hộp thoại menu cột",
             "CustomFilterDialogARIA": "Hộp thoại bộ lọc tùy chỉnh",
             "SortAtoZ": "Sắp xếp từ A đến Z",

--- a/src/zh.json
+++ b/src/zh.json
@@ -93,7 +93,7 @@
             "FilterMenuDialogARIA": "过滤器菜单对话框",
             "ExcelFilterDialogARIA": "Excel 过滤器对话框",
             "DialogEditARIA": "编辑对话框",
-            "ColumnChooserDialogARIA": "列选择器对话框",
+            "ColumnChooserDialogARIA": "列选择器",
             "ColumnMenuDialogARIA": "列菜单对话框",
             "CustomFilterDialogARIA": "自定义过滤器对话框",
             "SortAtoZ": "从 A 到 Z 排序",


### PR DESCRIPTION
### Bug description

Column-Chooser's checkbox state is not read properly by JAWS screen reader..

### Root cause

Aria-checked attribute is not added for selectAll checkbox.

### Reason for not identifying earlier

Find how it was missed in our earlier testing and development by analyzing the below checklist. This will help prevent similar mistakes in the future.

- [ ] Guidelines/documents are not followed

- Common guidelines / Core team guideline

- Specification document

- Requirement document

- [x] Guidelines/documents are not given

- Common guidelines / Core team guideline

- Specification document

- Requirement document

### Reason:

Guidelines/documents are not given - Requirement document

### Action taken:

Added Manual sample for this case. PR for the sample
https://github.com/essential-studio/ej2-grids-e2e/pull/292

### Related areas:

Checkbox, Filter Menu, Excel Menu

### Is it a breaking issue?

No

### Solution description

Removed the dialog word from aria-label of column chooser

### Output screenshots

No

### Areas affected and ensured

Column chooser, Checkbox, Filter Menu, Excel Menu

### Additional checklist

This may vary for different teams or products. Check with your scrum masters.

- Did you run the automation against your fix? - No

- Is there any API name change? - No

- Is there any existing behavior change of other features due to this code change? - No

- Does your new code introduce new warnings or binding errors? - No

- Does your code pass all FxCop and StyleCop rules? a- No

- Did you record this case in the unit test or UI test? -  No
