### PR TITLE
Bug(854718) : Need to add the aria label attribute to the link in the Rich Text Editor - Master

### DIFF
--- a/src/ar-AE.json
+++ b/src/ar-AE.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "اكتب للبحث",
       "emojiPickerNoResultFound": "لم يتم العثور على نتائج",
       "emojiPickerTrySomethingElse": "جرب شيئًا آخر",
-      "imageAriaLabel": "افتح في نافذة جديدة"
+      "linkAriaLabel": "افتح في نافذة جديدة"
     },
     "colorpicker": {
       "Apply": "تطبيق",

--- a/src/ar-AE.json
+++ b/src/ar-AE.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "الصق التعليمات البرمجية المضمنة هنا",
       "emojiPickerTypeToFind": "اكتب للبحث",
       "emojiPickerNoResultFound": "لم يتم العثور على نتائج",
-      "emojiPickerTrySomethingElse": "جرب شيئًا آخر"
+      "emojiPickerTrySomethingElse": "جرب شيئًا آخر",
+      "imageAriaLabel": "افتح في نافذة جديدة"
     },
     "colorpicker": {
       "Apply": "تطبيق",

--- a/src/ar.json
+++ b/src/ar.json
@@ -1277,7 +1277,7 @@
       "emojiPickerTypeToFind": "اكتب للبحث",
       "emojiPickerNoResultFound": "لم يتم العثور على نتائج",
       "emojiPickerTrySomethingElse": "جرب شيئًا آخر",
-      "imageAriaLabel": "افتح في نافذة جديدة"
+      "linkAriaLabel": "افتح في نافذة جديدة"
     },
     "colorpicker": {
       "Apply": "تطبيق",

--- a/src/ar.json
+++ b/src/ar.json
@@ -1276,7 +1276,8 @@
       "pasteEmbeddedCodeHere": "الصق التعليمات البرمجية المضمنة هنا",
       "emojiPickerTypeToFind": "اكتب للبحث",
       "emojiPickerNoResultFound": "لم يتم العثور على نتائج",
-      "emojiPickerTrySomethingElse": "جرب شيئًا آخر"
+      "emojiPickerTrySomethingElse": "جرب شيئًا آخر",
+      "imageAriaLabel": "افتح في نافذة جديدة"
     },
     "colorpicker": {
       "Apply": "تطبيق",

--- a/src/cs.json
+++ b/src/cs.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "Sem vložte vložený kód",
       "emojiPickerTypeToFind": "Zadejte a vyhledejte",
       "emojiPickerNoResultFound": "Nebyly nalezeny žádné výsledky",
-      "emojiPickerTrySomethingElse": "Zkuste něco jiného"
+      "emojiPickerTrySomethingElse": "Zkuste něco jiného",
+      "imageAriaLabel": "Otevři v novém okně"
     },
     "colorpicker": {
       "Apply": "Aplikovat",

--- a/src/cs.json
+++ b/src/cs.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "Zadejte a vyhledejte",
       "emojiPickerNoResultFound": "Nebyly nalezeny žádné výsledky",
       "emojiPickerTrySomethingElse": "Zkuste něco jiného",
-      "imageAriaLabel": "Otevři v novém okně"
+      "linkAriaLabel": "Otevři v novém okně"
     },
     "colorpicker": {
       "Apply": "Aplikovat",

--- a/src/da.json
+++ b/src/da.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "Skriv for at finde",
       "emojiPickerNoResultFound": "Ingen resultater fundet",
       "emojiPickerTrySomethingElse": "Prøv noget andet",
-      "imageAriaLabel": "Åbn i nyt vindue"
+      "linkAriaLabel": "Åbn i nyt vindue"
     },
     "colorpicker": {
       "Apply": "ansøge",

--- a/src/da.json
+++ b/src/da.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "Indsæt Embedded Code her",
       "emojiPickerTypeToFind": "Skriv for at finde",
       "emojiPickerNoResultFound": "Ingen resultater fundet",
-      "emojiPickerTrySomethingElse": "Prøv noget andet"
+      "emojiPickerTrySomethingElse": "Prøv noget andet",
+      "imageAriaLabel": "Åbn i nyt vindue"
     },
     "colorpicker": {
       "Apply": "ansøge",

--- a/src/de.json
+++ b/src/de.json
@@ -1276,7 +1276,8 @@
       "pasteEmbeddedCodeHere": "Fügen Sie hier eingebetteten Code ein",
       "emojiPickerTypeToFind": "Geben Sie „Suchen“ ein",
       "emojiPickerNoResultFound": "keine Ergebnisse gefunden",
-      "emojiPickerTrySomethingElse": "Versuchen Sie etwas anderes"
+      "emojiPickerTrySomethingElse": "Versuchen Sie etwas anderes",
+      "imageAriaLabel": "In einem neuen Fenster öffnen"
     },
     "colorpicker": {
       "Apply": "Übernehmen",

--- a/src/de.json
+++ b/src/de.json
@@ -1277,7 +1277,7 @@
       "emojiPickerTypeToFind": "Geben Sie „Suchen“ ein",
       "emojiPickerNoResultFound": "keine Ergebnisse gefunden",
       "emojiPickerTrySomethingElse": "Versuchen Sie etwas anderes",
-      "imageAriaLabel": "In einem neuen Fenster öffnen"
+      "linkAriaLabel": "In einem neuen Fenster öffnen"
     },
     "colorpicker": {
       "Apply": "Übernehmen",

--- a/src/en-GB.json
+++ b/src/en-GB.json
@@ -1276,7 +1276,8 @@
             "pasteEmbeddedCodeHere": "Paste Embedded Code here",
             "emojiPickerTypeToFind": "Type to find",
             "emojiPickerNoResultFound": "No results found",
-            "emojiPickerTrySomethingElse": "Try something else"
+            "emojiPickerTrySomethingElse": "Try something else",
+            "imageAriaLabel": "Open in new window"
         },
         "colorpicker": {
             "Apply": "Apply",

--- a/src/en-GB.json
+++ b/src/en-GB.json
@@ -1277,7 +1277,7 @@
             "emojiPickerTypeToFind": "Type to find",
             "emojiPickerNoResultFound": "No results found",
             "emojiPickerTrySomethingElse": "Try something else",
-            "imageAriaLabel": "Open in new window"
+            "linkAriaLabel": "Open in new window"
         },
         "colorpicker": {
             "Apply": "Apply",

--- a/src/en-US.json
+++ b/src/en-US.json
@@ -1278,7 +1278,7 @@
             "emojiPickerTypeToFind": "Type to find",
             "emojiPickerNoResultFound": "No results found",
             "emojiPickerTrySomethingElse": "Try something else",
-            "imageAriaLabel": "Open in new window"
+            "linkAriaLabel": "Open in new window"
         },
         "colorpicker": {
             "Apply": "Apply",

--- a/src/en-US.json
+++ b/src/en-US.json
@@ -1277,7 +1277,8 @@
             "pasteEmbeddedCodeHere": "Paste Embedded Code here",
             "emojiPickerTypeToFind": "Type to find",
             "emojiPickerNoResultFound": "No results found",
-            "emojiPickerTrySomethingElse": "Try something else"
+            "emojiPickerTrySomethingElse": "Try something else",
+            "imageAriaLabel": "Open in new window"
         },
         "colorpicker": {
             "Apply": "Apply",

--- a/src/es.json
+++ b/src/es.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "Pegue el código incrustado aquí",
       "emojiPickerTypeToFind": "Escriba para encontrar",
       "emojiPickerNoResultFound": "No se han encontrado resultados",
-      "emojiPickerTrySomethingElse": "Prueba algo más"
+      "emojiPickerTrySomethingElse": "Prueba algo más",
+      "imageAriaLabel": "Abrir en Nueva ventana"
     },
     "colorpicker": {
       "Apply": "Aplicar",

--- a/src/es.json
+++ b/src/es.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "Escriba para encontrar",
       "emojiPickerNoResultFound": "No se han encontrado resultados",
       "emojiPickerTrySomethingElse": "Prueba algo más",
-      "imageAriaLabel": "Abrir en Nueva ventana"
+      "linkAriaLabel": "Abrir en Nueva ventana"
     },
     "colorpicker": {
       "Apply": "Aplicar",

--- a/src/fa.json
+++ b/src/fa.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "کد جاسازی شده را اینجا بچسبانید",
       "emojiPickerTypeToFind": "برای پیدا کردن تایپ کنید",
       "emojiPickerNoResultFound": "نتیجه ای پیدا نشد",
-      "emojiPickerTrySomethingElse": "چیز دیگری را امتحان کنید"
+      "emojiPickerTrySomethingElse": "چیز دیگری را امتحان کنید",
+      "imageAriaLabel": "باز کردن در پنجره جدید"
     },
     "colorpicker": {
       "Apply": "درخواست دادن",

--- a/src/fa.json
+++ b/src/fa.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "برای پیدا کردن تایپ کنید",
       "emojiPickerNoResultFound": "نتیجه ای پیدا نشد",
       "emojiPickerTrySomethingElse": "چیز دیگری را امتحان کنید",
-      "imageAriaLabel": "باز کردن در پنجره جدید"
+      "linkAriaLabel": "باز کردن در پنجره جدید"
     },
     "colorpicker": {
       "Apply": "درخواست دادن",

--- a/src/fi.json
+++ b/src/fi.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "Kirjoita löytääksesi",
       "emojiPickerNoResultFound": "Ei tuloksia",
       "emojiPickerTrySomethingElse": "Kokeile jotain muuta",
-      "imageAriaLabel": "Avaa uudessa ikkunassa"
+      "linkAriaLabel": "Avaa uudessa ikkunassa"
     },
     "colorpicker": {
       "Apply": "Käytä",

--- a/src/fi.json
+++ b/src/fi.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "Liitä upotettu koodi tähän",
       "emojiPickerTypeToFind": "Kirjoita löytääksesi",
       "emojiPickerNoResultFound": "Ei tuloksia",
-      "emojiPickerTrySomethingElse": "Kokeile jotain muuta"
+      "emojiPickerTrySomethingElse": "Kokeile jotain muuta",
+      "imageAriaLabel": "Avaa uudessa ikkunassa"
     },
     "colorpicker": {
       "Apply": "Käytä",

--- a/src/fr.json
+++ b/src/fr.json
@@ -1276,7 +1276,8 @@
       "pasteEmbeddedCodeHere": "Collez le code intégré ici",
       "emojiPickerTypeToFind": "Tapez pour trouver",
       "emojiPickerNoResultFound": "Aucun résultat trouvé",
-      "emojiPickerTrySomethingElse": "Essayez autre chose"
+      "emojiPickerTrySomethingElse": "Essayez autre chose",
+      "imageAriaLabel": "Ouvrir dans une nouvelle fenêtre"
     },
     "colorpicker": {
       "Apply": "Appliquer",

--- a/src/fr.json
+++ b/src/fr.json
@@ -1277,7 +1277,7 @@
       "emojiPickerTypeToFind": "Tapez pour trouver",
       "emojiPickerNoResultFound": "Aucun résultat trouvé",
       "emojiPickerTrySomethingElse": "Essayez autre chose",
-      "imageAriaLabel": "Ouvrir dans une nouvelle fenêtre"
+      "linkAriaLabel": "Ouvrir dans une nouvelle fenêtre"
     },
     "colorpicker": {
       "Apply": "Appliquer",

--- a/src/he.json
+++ b/src/he.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "הדבק כאן קוד מוטבע",
       "emojiPickerTypeToFind": "הקלד כדי למצוא",
       "emojiPickerNoResultFound": "לא נמצאו תוצאות",
-      "emojiPickerTrySomethingElse": "נסה משהו אחר"
+      "emojiPickerTrySomethingElse": "נסה משהו אחר",
+      "imageAriaLabel": "פתח בחלון חדש"
     },
     "colorpicker": {
       "Apply": "להגיש מועמדות",

--- a/src/he.json
+++ b/src/he.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "הקלד כדי למצוא",
       "emojiPickerNoResultFound": "לא נמצאו תוצאות",
       "emojiPickerTrySomethingElse": "נסה משהו אחר",
-      "imageAriaLabel": "פתח בחלון חדש"
+      "linkAriaLabel": "פתח בחלון חדש"
     },
     "colorpicker": {
       "Apply": "להגיש מועמדות",

--- a/src/hr.json
+++ b/src/hr.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "Ovdje zalijepite ugrađeni kod",
       "emojiPickerTypeToFind": "Upišite za pronalaženje",
       "emojiPickerNoResultFound": "Nema rezultata",
-      "emojiPickerTrySomethingElse": "Pokušajte nešto drugo"
+      "emojiPickerTrySomethingElse": "Pokušajte nešto drugo",
+      "imageAriaLabel": "Otvori u novom prozoru"
     },
     "colorpicker": {
       "Apply": "primijeniti",

--- a/src/hr.json
+++ b/src/hr.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "Upišite za pronalaženje",
       "emojiPickerNoResultFound": "Nema rezultata",
       "emojiPickerTrySomethingElse": "Pokušajte nešto drugo",
-      "imageAriaLabel": "Otvori u novom prozoru"
+      "linkAriaLabel": "Otvori u novom prozoru"
     },
     "colorpicker": {
       "Apply": "primijeniti",

--- a/src/hu.json
+++ b/src/hu.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "Illessze be a beágyazott kódot ide",
       "emojiPickerTypeToFind": "Írja be a kereséshez",
       "emojiPickerNoResultFound": "Nincs találat",
-      "emojiPickerTrySomethingElse": "Próbálj ki valami mást"
+      "emojiPickerTrySomethingElse": "Próbálj ki valami mást",
+      "imageAriaLabel": "Megnyitás új ablakban"
     },
     "colorpicker": {
       "Apply": "Alkalmaz",

--- a/src/hu.json
+++ b/src/hu.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "Írja be a kereséshez",
       "emojiPickerNoResultFound": "Nincs találat",
       "emojiPickerTrySomethingElse": "Próbálj ki valami mást",
-      "imageAriaLabel": "Megnyitás új ablakban"
+      "linkAriaLabel": "Megnyitás új ablakban"
     },
     "colorpicker": {
       "Apply": "Alkalmaz",

--- a/src/id.json
+++ b/src/id.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "Tempel Kode Tersemat di sini",
       "emojiPickerTypeToFind": "Ketik untuk menemukan",
       "emojiPickerNoResultFound": "Tidak ada hasil yang ditemukan",
-      "emojiPickerTrySomethingElse": "Cobalah sesuatu yang lain"
+      "emojiPickerTrySomethingElse": "Cobalah sesuatu yang lain",
+      "imageAriaLabel": "Buka di jendela baru"
     },
     "colorpicker": {
       "Apply": "Menerapkan",

--- a/src/id.json
+++ b/src/id.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "Ketik untuk menemukan",
       "emojiPickerNoResultFound": "Tidak ada hasil yang ditemukan",
       "emojiPickerTrySomethingElse": "Cobalah sesuatu yang lain",
-      "imageAriaLabel": "Buka di jendela baru"
+      "linkAriaLabel": "Buka di jendela baru"
     },
     "colorpicker": {
       "Apply": "Menerapkan",

--- a/src/is.json
+++ b/src/is.json
@@ -1223,7 +1223,7 @@
       "emojiPickerTypeToFind": "Sláðu inn til að finna",
       "emojiPickerNoResultFound": "Engar niðurstöður fundust",
       "emojiPickerTrySomethingElse": "Prófaðu eitthvað annað",
-      "imageAriaLabel": "Opna í nýjum glugga"
+      "linkAriaLabel": "Opna í nýjum glugga"
     },
     "colorpicker": {
       "Apply": "Sækja um",

--- a/src/is.json
+++ b/src/is.json
@@ -1222,7 +1222,8 @@
       "pasteEmbeddedCodeHere": "Límdu innbyggðan kóða hér",
       "emojiPickerTypeToFind": "Sláðu inn til að finna",
       "emojiPickerNoResultFound": "Engar niðurstöður fundust",
-      "emojiPickerTrySomethingElse": "Prófaðu eitthvað annað"
+      "emojiPickerTrySomethingElse": "Prófaðu eitthvað annað",
+      "imageAriaLabel": "Opna í nýjum glugga"
     },
     "colorpicker": {
       "Apply": "Sækja um",

--- a/src/it.json
+++ b/src/it.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "Incolla qui il codice incorporato",
       "emojiPickerTypeToFind": "Digita per trovare",
       "emojiPickerNoResultFound": "nessun risultato trovato",
-      "emojiPickerTrySomethingElse": "Prova qualcos'altro"
+      "emojiPickerTrySomethingElse": "Prova qualcos'altro",
+      "imageAriaLabel": "Apri in una nuova finestra"
     },
     "colorpicker": {
       "Apply": "Applicare",

--- a/src/it.json
+++ b/src/it.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "Digita per trovare",
       "emojiPickerNoResultFound": "nessun risultato trovato",
       "emojiPickerTrySomethingElse": "Prova qualcos'altro",
-      "imageAriaLabel": "Apri in una nuova finestra"
+      "linkAriaLabel": "Apri in una nuova finestra"
     },
     "colorpicker": {
       "Apply": "Applicare",

--- a/src/ja.json
+++ b/src/ja.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "ここに埋め込みコードを貼り付けます",
       "emojiPickerTypeToFind": "検索する文字を入力してください",
       "emojiPickerNoResultFound": "結果が見つかりません",
-      "emojiPickerTrySomethingElse": "何か別のことを試してみる"
+      "emojiPickerTrySomethingElse": "何か別のことを試してみる",
+      "imageAriaLabel": "新しいウィンドウで開きます"
     },
     "colorpicker": {
       "Apply": "適用する",

--- a/src/ja.json
+++ b/src/ja.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "検索する文字を入力してください",
       "emojiPickerNoResultFound": "結果が見つかりません",
       "emojiPickerTrySomethingElse": "何か別のことを試してみる",
-      "imageAriaLabel": "新しいウィンドウで開きます"
+      "linkAriaLabel": "新しいウィンドウで開きます"
     },
     "colorpicker": {
       "Apply": "適用する",

--- a/src/ko.json
+++ b/src/ko.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "찾으려면 입력",
       "emojiPickerNoResultFound": "검색 결과가 없습니다",
       "emojiPickerTrySomethingElse": "다른 것을 시도하십시오",
-      "imageAriaLabel": "새 창에서 열기"
+      "linkAriaLabel": "새 창에서 열기"
     },
     "colorpicker": {
       "Apply": "대다",

--- a/src/ko.json
+++ b/src/ko.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "여기에 임베디드 코드 붙여넣기",
       "emojiPickerTypeToFind": "찾으려면 입력",
       "emojiPickerNoResultFound": "검색 결과가 없습니다",
-      "emojiPickerTrySomethingElse": "다른 것을 시도하십시오"
+      "emojiPickerTrySomethingElse": "다른 것을 시도하십시오",
+      "imageAriaLabel": "새 창에서 열기"
     },
     "colorpicker": {
       "Apply": "대다",

--- a/src/ms.json
+++ b/src/ms.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "Tampal Kod Terbenam di sini",
       "emojiPickerTypeToFind": "Taip untuk mencari",
       "emojiPickerNoResultFound": "Tiada keputusan dijumpai",
-      "emojiPickerTrySomethingElse": "Cuba sesuatu yang lain"
+      "emojiPickerTrySomethingElse": "Cuba sesuatu yang lain",
+      "imageAriaLabel": "Buka dalam tetingkap baharu"
     },
     "colorpicker": {
       "Apply": "Sapukan",

--- a/src/ms.json
+++ b/src/ms.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "Taip untuk mencari",
       "emojiPickerNoResultFound": "Tiada keputusan dijumpai",
       "emojiPickerTrySomethingElse": "Cuba sesuatu yang lain",
-      "imageAriaLabel": "Buka dalam tetingkap baharu"
+      "linkAriaLabel": "Buka dalam tetingkap baharu"
     },
     "colorpicker": {
       "Apply": "Sapukan",

--- a/src/nb.json
+++ b/src/nb.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "Skriv for å finne",
       "emojiPickerNoResultFound": "Ingen resultater",
       "emojiPickerTrySomethingElse": "Prøv noe annet",
-      "imageAriaLabel": "Åpne i nytt vindu"
+      "linkAriaLabel": "Åpne i nytt vindu"
     },
     "colorpicker": {
       "Apply": "Søke om",

--- a/src/nb.json
+++ b/src/nb.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "Lim inn innebygd kode her",
       "emojiPickerTypeToFind": "Skriv for å finne",
       "emojiPickerNoResultFound": "Ingen resultater",
-      "emojiPickerTrySomethingElse": "Prøv noe annet"
+      "emojiPickerTrySomethingElse": "Prøv noe annet",
+      "imageAriaLabel": "Åpne i nytt vindu"
     },
     "colorpicker": {
       "Apply": "Søke om",

--- a/src/nl.json
+++ b/src/nl.json
@@ -1275,7 +1275,7 @@
           "emojiPickerTypeToFind": "Typ om te vinden",
           "emojiPickerNoResultFound": "geen resultaten gevonden",
           "emojiPickerTrySomethingElse": "Probeer iets anders",
-          "imageAriaLabel": "Openen in een nieuw venster"
+          "linkAriaLabel": "Openen in een nieuw venster"
       },
       "colorpicker": {
           "Apply": "Toepassen",

--- a/src/nl.json
+++ b/src/nl.json
@@ -1274,7 +1274,8 @@
           "pasteEmbeddedCodeHere": "Plak hier de ingesloten code",
           "emojiPickerTypeToFind": "Typ om te vinden",
           "emojiPickerNoResultFound": "geen resultaten gevonden",
-          "emojiPickerTrySomethingElse": "Probeer iets anders"
+          "emojiPickerTrySomethingElse": "Probeer iets anders",
+          "imageAriaLabel": "Openen in een nieuw venster"
       },
       "colorpicker": {
           "Apply": "Toepassen",

--- a/src/pl.json
+++ b/src/pl.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "Wpisz, aby znaleźć",
       "emojiPickerNoResultFound": "Nie znaleziono wyników",
       "emojiPickerTrySomethingElse": "Spróbuj czegoś innego",
-      "imageAriaLabel": "Otworzyć w nowym oknie"
+      "linkAriaLabel": "Otworzyć w nowym oknie"
     },
     "colorpicker": {
       "Apply": "Zastosować",

--- a/src/pl.json
+++ b/src/pl.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "Wklej kod osadzony tutaj",
       "emojiPickerTypeToFind": "Wpisz, aby znaleźć",
       "emojiPickerNoResultFound": "Nie znaleziono wyników",
-      "emojiPickerTrySomethingElse": "Spróbuj czegoś innego"
+      "emojiPickerTrySomethingElse": "Spróbuj czegoś innego",
+      "imageAriaLabel": "Otworzyć w nowym oknie"
     },
     "colorpicker": {
       "Apply": "Zastosować",

--- a/src/pt-BR.json
+++ b/src/pt-BR.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "Cole o código incorporado aqui",
       "emojiPickerTypeToFind": "Digite para encontrar",
       "emojiPickerNoResultFound": "Nenhum resultado encontrado",
-      "emojiPickerTrySomethingElse": "tente outra coisa"
+      "emojiPickerTrySomethingElse": "tente outra coisa",
+      "imageAriaLabel": "Abrir em nova janela"
     },
     "colorpicker": {
       "Apply": "Aplicar",

--- a/src/pt-BR.json
+++ b/src/pt-BR.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "Digite para encontrar",
       "emojiPickerNoResultFound": "Nenhum resultado encontrado",
       "emojiPickerTrySomethingElse": "tente outra coisa",
-      "imageAriaLabel": "Abrir em nova janela"
+      "linkAriaLabel": "Abrir em nova janela"
     },
     "colorpicker": {
       "Apply": "Aplicar",

--- a/src/pt.json
+++ b/src/pt.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "Cole o código incorporado aqui",
       "emojiPickerTypeToFind": "Digite para encontrar",
       "emojiPickerNoResultFound": "Nenhum resultado encontrado",
-      "emojiPickerTrySomethingElse": "tente outra coisa"
+      "emojiPickerTrySomethingElse": "tente outra coisa",
+      "imageAriaLabel": "Abrir em nova janela"
     },
     "colorpicker": {
       "Apply": "Aplique",

--- a/src/pt.json
+++ b/src/pt.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "Digite para encontrar",
       "emojiPickerNoResultFound": "Nenhum resultado encontrado",
       "emojiPickerTrySomethingElse": "tente outra coisa",
-      "imageAriaLabel": "Abrir em nova janela"
+      "linkAriaLabel": "Abrir em nova janela"
     },
     "colorpicker": {
       "Apply": "Aplique",

--- a/src/ro.json
+++ b/src/ro.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "Tastați pentru a găsi",
       "emojiPickerNoResultFound": "Nici un rezultat gasit",
       "emojiPickerTrySomethingElse": "Încearcă altceva",
-      "imageAriaLabel": "Deschide într-o fereastră nouă"
+      "linkAriaLabel": "Deschide într-o fereastră nouă"
     },
     "colorpicker": {
       "Apply": "aplica",

--- a/src/ro.json
+++ b/src/ro.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "Lipiți codul încorporat aici",
       "emojiPickerTypeToFind": "Tastați pentru a găsi",
       "emojiPickerNoResultFound": "Nici un rezultat gasit",
-      "emojiPickerTrySomethingElse": "Încearcă altceva"
+      "emojiPickerTrySomethingElse": "Încearcă altceva",
+      "imageAriaLabel": "Deschide într-o fereastră nouă"
     },
     "colorpicker": {
       "Apply": "aplica",

--- a/src/ru.json
+++ b/src/ru.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "Введите, чтобы найти",
       "emojiPickerNoResultFound": "результатов не найдено",
       "emojiPickerTrySomethingElse": "Попробуйте что-нибудь другое",
-      "imageAriaLabel": "Открыть в новом окне"
+      "linkAriaLabel": "Открыть в новом окне"
     },
     "colorpicker": {
       "Apply": "Подать заявление",

--- a/src/ru.json
+++ b/src/ru.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "Вставьте встроенный код сюда",
       "emojiPickerTypeToFind": "Введите, чтобы найти",
       "emojiPickerNoResultFound": "результатов не найдено",
-      "emojiPickerTrySomethingElse": "Попробуйте что-нибудь другое"
+      "emojiPickerTrySomethingElse": "Попробуйте что-нибудь другое",
+      "imageAriaLabel": "Открыть в новом окне"
     },
     "colorpicker": {
       "Apply": "Подать заявление",

--- a/src/sk.json
+++ b/src/sk.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "Ak chcete nájsť, zadajte",
       "emojiPickerNoResultFound": "Neboli nájdené žiadne výsledky",
       "emojiPickerTrySomethingElse": "Skúste niečo iné",
-      "imageAriaLabel": "Otvoriť v novom okne"
+      "linkAriaLabel": "Otvoriť v novom okne"
     },
     "colorpicker": {
       "Apply": "platiť",

--- a/src/sk.json
+++ b/src/sk.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "Sem vložte vložený kód",
       "emojiPickerTypeToFind": "Ak chcete nájsť, zadajte",
       "emojiPickerNoResultFound": "Neboli nájdené žiadne výsledky",
-      "emojiPickerTrySomethingElse": "Skúste niečo iné"
+      "emojiPickerTrySomethingElse": "Skúste niečo iné",
+      "imageAriaLabel": "Otvoriť v novom okne"
     },
     "colorpicker": {
       "Apply": "platiť",

--- a/src/sv.json
+++ b/src/sv.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "Klistra in inbäddad kod här",
       "emojiPickerTypeToFind": "Skriv för att hitta",
       "emojiPickerNoResultFound": "Inga resultat funna",
-      "emojiPickerTrySomethingElse": "Prova något annat"
+      "emojiPickerTrySomethingElse": "Prova något annat",
+      "imageAriaLabel": "Öppna i nytt fönster"
     },
     "colorpicker": {
       "Apply": "Tillämpa",

--- a/src/sv.json
+++ b/src/sv.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "Skriv för att hitta",
       "emojiPickerNoResultFound": "Inga resultat funna",
       "emojiPickerTrySomethingElse": "Prova något annat",
-      "imageAriaLabel": "Öppna i nytt fönster"
+      "linkAriaLabel": "Öppna i nytt fönster"
     },
     "colorpicker": {
       "Apply": "Tillämpa",

--- a/src/th.json
+++ b/src/th.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "พิมพ์เพื่อค้นหา",
       "emojiPickerNoResultFound": "ไม่พบผลลัพธ์",
       "emojiPickerTrySomethingElse": "ลองอย่างอื่น",
-      "imageAriaLabel": "เปิดหน้าต่างใหม่"
+      "linkAriaLabel": "เปิดหน้าต่างใหม่"
     },
     "colorpicker": {
       "Apply": "ใช้",

--- a/src/th.json
+++ b/src/th.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "วางรหัสฝังตัวที่นี่",
       "emojiPickerTypeToFind": "พิมพ์เพื่อค้นหา",
       "emojiPickerNoResultFound": "ไม่พบผลลัพธ์",
-      "emojiPickerTrySomethingElse": "ลองอย่างอื่น"
+      "emojiPickerTrySomethingElse": "ลองอย่างอื่น",
+      "imageAriaLabel": "เปิดหน้าต่างใหม่"
     },
     "colorpicker": {
       "Apply": "ใช้",

--- a/src/tr.json
+++ b/src/tr.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "Gömülü Kodu buraya yapıştırın",
       "emojiPickerTypeToFind": "Bulmak için yazın",
       "emojiPickerNoResultFound": "Sonuç bulunamadı",
-      "emojiPickerTrySomethingElse": "başka bir şey dene"
+      "emojiPickerTrySomethingElse": "başka bir şey dene",
+      "imageAriaLabel": "Yeni pencerede aç"
     },
     "colorpicker": {
       "Apply": "Uygulamak",

--- a/src/tr.json
+++ b/src/tr.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "Bulmak için yazın",
       "emojiPickerNoResultFound": "Sonuç bulunamadı",
       "emojiPickerTrySomethingElse": "başka bir şey dene",
-      "imageAriaLabel": "Yeni pencerede aç"
+      "linkAriaLabel": "Yeni pencerede aç"
     },
     "colorpicker": {
       "Apply": "Uygulamak",

--- a/src/vi.json
+++ b/src/vi.json
@@ -1274,7 +1274,8 @@
       "pasteEmbeddedCodeHere": "Dán mã nhúng vào đây",
       "emojiPickerTypeToFind": "Nhập để tìm",
       "emojiPickerNoResultFound": "không có kết quả nào được tìm thấy",
-      "emojiPickerTrySomethingElse": "Hãy thử một cái gì đó khác"
+      "emojiPickerTrySomethingElse": "Hãy thử một cái gì đó khác",
+      "imageAriaLabel": "Mở trong cửa sổ mới"
     },
     "colorpicker": {
       "Apply": "Ứng dụng",

--- a/src/vi.json
+++ b/src/vi.json
@@ -1275,7 +1275,7 @@
       "emojiPickerTypeToFind": "Nhập để tìm",
       "emojiPickerNoResultFound": "không có kết quả nào được tìm thấy",
       "emojiPickerTrySomethingElse": "Hãy thử một cái gì đó khác",
-      "imageAriaLabel": "Mở trong cửa sổ mới"
+      "linkAriaLabel": "Mở trong cửa sổ mới"
     },
     "colorpicker": {
       "Apply": "Ứng dụng",

--- a/src/zh.json
+++ b/src/zh.json
@@ -1276,7 +1276,8 @@
       "pasteEmbeddedCodeHere": "将嵌入代码粘贴到此处",
       "emojiPickerTypeToFind": "键入以查找",
       "emojiPickerNoResultFound": "未找到结果",
-      "emojiPickerTrySomethingElse": "尝试别的东西"
+      "emojiPickerTrySomethingElse": "尝试别的东西",
+      "imageAriaLabel": "在新窗口中打开"
     },
     "colorpicker": {
       "Apply": "應用",

--- a/src/zh.json
+++ b/src/zh.json
@@ -1277,7 +1277,7 @@
       "emojiPickerTypeToFind": "键入以查找",
       "emojiPickerNoResultFound": "未找到结果",
       "emojiPickerTrySomethingElse": "尝试别的东西",
-      "imageAriaLabel": "在新窗口中打开"
+      "linkAriaLabel": "在新窗口中打开"
     },
     "colorpicker": {
       "Apply": "應用",


### PR DESCRIPTION
### Bug description
Need to add the aria label attribute to the link in the Rich Text Editor.

### Root Cause / Analysis
I have analyzed the issue and then added the aria-label attribute based on the target of the link.

### Reason for not identifying earlier
This particular use case has not been tested previously.

### Is Breaking issue.?
No

### Is reported by customer in incident/forum.?
Forum : https://forumassist.syncfusion.com/185225 

### Solution Description
I have added the aria-label attribute to the link.

### Areas affected and ensured
Yes

### E2E report details against this fix
No

### Did you included unit test cases.?
No

### Is there any API name changes.?
No

/label ~bug
/assign @ScrumMaster
/cc @ProductOwner