### PR TITLE
Update de.json okText

### DIFF
--- a/src/de.json
+++ b/src/de.json
@@ -1070,7 +1070,7 @@
       "collapseAll": "Alles einklappen",
       "nextTimeSpan": "Nächste Zeitspanne",
       "prevTimeSpan": "Vorherige Zeitspanne",
-      "okText": "In Ordnung",
+      "okText": "OK",
       "confirmDelete": "Möchten Sie den Datensatz wirklich löschen?",
       "from": "Von",
       "to": "Bis",


### PR DESCRIPTION
 was way too long and was stacking buttons in the filter dialog for grid, in another place Ok is translated as Ok so it should be consistent too.

![image](https://github.com/syncfusion/ej2-locale/assets/107770821/e3c31a6b-df17-49e3-ab86-7f93e4a6656e)

https://www.syncfusion.com/forums/185585/grid-datetime-time-picker-gets-broken-by-internationalization?reply=z9S2Co