### PR TITLE
Fix Count-Template for Drop Down

### DIFF
--- a/src/ar-AE.json
+++ b/src/ar-AE.json
@@ -2111,8 +2111,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "لا توجد سجلات",
       "actionFailureTemplate": "الطلب فشل",
-      "overflowCountTemplate": "+ $ {count} أكثر ..",
-      "totalCountTemplate": "تم اختيار {عدد} دولار"
+      "overflowCountTemplate": "+ ${count} أكثر ..",
+      "totalCountTemplate": "تم اختيار ${count} دولار"
     },
     "documenteditor": {
       "Table": "الطاولة",

--- a/src/ar.json
+++ b/src/ar.json
@@ -2113,8 +2113,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "لا توجد سجلات",
       "actionFailureTemplate": "الطلب فشل",
-      "overflowCountTemplate": "+ $ {count} أكثر ..",
-      "totalCountTemplate": "تم اختيار {عدد} دولار"
+      "overflowCountTemplate": "+ ${count} أكثر ..",
+      "totalCountTemplate": "تم اختيار ${count} دولار"
     },
     "documenteditor": {
       "Table": "الطاولة",

--- a/src/cs.json
+++ b/src/cs.json
@@ -2111,8 +2111,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "Nenalezeny žádné záznamy",
       "actionFailureTemplate": "Požadavek selhal",
-      "overflowCountTemplate": "+ $ {count} další ..",
-      "totalCountTemplate": "Vybráno $ {count}"
+      "overflowCountTemplate": "+ ${count} další ..",
+      "totalCountTemplate": "Vybráno ${count}"
     },
     "documenteditor": {
       "Table": "Stůl",

--- a/src/da.json
+++ b/src/da.json
@@ -2111,8 +2111,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "Ingen optegnelser fundet",
       "actionFailureTemplate": "Anmodningen mislykkedes",
-      "overflowCountTemplate": "+ $ {count} mere ..",
-      "totalCountTemplate": "$ {count} valgt"
+      "overflowCountTemplate": "+ ${count} mere ..",
+      "totalCountTemplate": "${count} valgt"
     },
     "documenteditor": {
       "Table": "Bord",

--- a/src/de.json
+++ b/src/de.json
@@ -2113,8 +2113,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "Keine Aufzeichnungen gefunden",
       "actionFailureTemplate": "Anfrage fehlgeschlagen",
-      "overflowCountTemplate": "+ $ {count} mehr ..",
-      "totalCountTemplate": "$ {count} ausgewählt"
+      "overflowCountTemplate": "+ ${count} mehr ..",
+      "totalCountTemplate": "${count} ausgewählt"
     },
     "documenteditor": {
       "Table": "Tabelle",

--- a/src/es.json
+++ b/src/es.json
@@ -2114,8 +2114,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "No se encontraron registros",
       "actionFailureTemplate": "Solicitud fallida",
-      "overflowCountTemplate": "+ $ {count} más ...",
-      "totalCountTemplate": "$ {count} seleccionados"
+      "overflowCountTemplate": "+ ${count} más ...",
+      "totalCountTemplate": "${count} seleccionados"
     },
     "documenteditor": {
       "Table": "Mesa",

--- a/src/fa.json
+++ b/src/fa.json
@@ -1990,8 +1990,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "هیچ سوابقی یافت نشد",
       "actionFailureTemplate": "درخواست ناموفق بود",
-      "overflowCountTemplate": "+ $ {count} بیشتر ..",
-      "totalCountTemplate": "$ {count} انتخاب شد"
+      "overflowCountTemplate": "+ ${count} بیشتر ..",
+      "totalCountTemplate": "${count} انتخاب شد"
     },
     "documenteditor": {
       "Table": "جدول",

--- a/src/fi.json
+++ b/src/fi.json
@@ -2111,8 +2111,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "Merkintöjä ei löydy",
       "actionFailureTemplate": "Pyyntö epäonnistui",
-      "overflowCountTemplate": "+ $ {count} muuta ..",
-      "totalCountTemplate": "$ {count} valittu"
+      "overflowCountTemplate": "+ ${count} muuta ..",
+      "totalCountTemplate": "${count} valittu"
     },
     "documenteditor": {
       "Table": "Pöytä",

--- a/src/fr.json
+++ b/src/fr.json
@@ -2114,8 +2114,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "Aucun enregistrement trouvé",
       "actionFailureTemplate": "Demande échoué",
-      "overflowCountTemplate": "+ $ {count} de plus ..",
-      "totalCountTemplate": "$ {count} sélectionné"
+      "overflowCountTemplate": "+ ${count} de plus ..",
+      "totalCountTemplate": "${count} sélectionné"
     },
     "documenteditor": {
       "Table": "Tableau",

--- a/src/he.json
+++ b/src/he.json
@@ -2111,8 +2111,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "לא נמצאו שיאים",
       "actionFailureTemplate": "בקשה נכשלה",
-      "overflowCountTemplate": "+ $ {count} נוספים ..",
-      "totalCountTemplate": "נבחרה $ {count}"
+      "overflowCountTemplate": "+ ${count} נוספים ..",
+      "totalCountTemplate": "נבחרה ${count}"
     },
     "documenteditor": {
       "Table": "שולחן",

--- a/src/hr.json
+++ b/src/hr.json
@@ -2111,8 +2111,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "Ni najdenih zapisov",
       "actionFailureTemplate": "Zahteva ni uspela",
-      "overflowCountTemplate": "+ $ {count} več ..",
-      "totalCountTemplate": "$ {count} je izbrano"
+      "overflowCountTemplate": "+ ${count} več ..",
+      "totalCountTemplate": "${count} je izbrano"
     },
     "documenteditor": {
       "Table": "Stol",

--- a/src/hu.json
+++ b/src/hu.json
@@ -2111,8 +2111,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "Nincs találat",
       "actionFailureTemplate": "Kérés sikertelen",
-      "overflowCountTemplate": "+ további $ {count} ..",
-      "totalCountTemplate": "$ {count} kiválasztva"
+      "overflowCountTemplate": "+ további ${count} ..",
+      "totalCountTemplate": "${count} kiválasztva"
     },
     "documenteditor": {
       "Table": "asztal",

--- a/src/id.json
+++ b/src/id.json
@@ -2111,8 +2111,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "Tidak ada catatan yang ditemukan",
       "actionFailureTemplate": "Permintaan gagal",
-      "overflowCountTemplate": "+ $ {count} lagi ..",
-      "totalCountTemplate": "$ {count} dipilih"
+      "overflowCountTemplate": "+ ${count} lagi ..",
+      "totalCountTemplate": "${count} dipilih"
     },
     "documenteditor": {
       "Table": "Meja",

--- a/src/it.json
+++ b/src/it.json
@@ -2112,8 +2112,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "Nessun record trovato",
       "actionFailureTemplate": "Richiesta fallita",
-      "overflowCountTemplate": "+ $ {count} altro ..",
-      "totalCountTemplate": "$ {count} selezionato"
+      "overflowCountTemplate": "+ ${count} altro ..",
+      "totalCountTemplate": "${count} selezionato"
     },
     "documenteditor": {
       "Table": "Tabella",

--- a/src/ja.json
+++ b/src/ja.json
@@ -2111,8 +2111,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "レコードが見つかりません",
       "actionFailureTemplate": "要求が失敗しました",
-      "overflowCountTemplate": "+ $ {count}もっと..",
-      "totalCountTemplate": "$ {count}が選択されました"
+      "overflowCountTemplate": "+ ${count}もっと..",
+      "totalCountTemplate": "${count}が選択されました"
     },
     "documenteditor": {
       "Table": "テーブル",

--- a/src/ko.json
+++ b/src/ko.json
@@ -2111,8 +2111,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "기록 없음",
       "actionFailureTemplate": "요청 실패",
-      "overflowCountTemplate": "+ $ {count} 개 더 ..",
-      "totalCountTemplate": "$ {count} 선택됨"
+      "overflowCountTemplate": "+ ${count} 개 더 ..",
+      "totalCountTemplate": "${count} 선택됨"
     },
     "documenteditor": {
       "Table": "표",

--- a/src/ms.json
+++ b/src/ms.json
@@ -174,10 +174,10 @@
     "dropdowns": {
       "noRecordsTemplate": "Tiada rekod dijumpai",
       "actionFailureTemplate": "Permintaan Gagal",
-      "overflowCountTemplate": "+ $ {count} lagi ..",
+      "overflowCountTemplate": "+ ${count} lagi ..",
       "selectAllText": "Pilih semua",
       "unSelectAllText": "Nyahpilih Semua",
-      "totalCountTemplate": "$ {count} dipilih"
+      "totalCountTemplate": "${count} dipilih"
     },
     "drop-down-list": {
       "noRecordsTemplate": "Tiada rekod dijumpai",
@@ -194,10 +194,10 @@
     "multi-select": {
       "noRecordsTemplate": "Tiada rekod dijumpai",
       "actionFailureTemplate": "Permintaan Gagal",
-      "overflowCountTemplate": "+ $ {count} lagi ..",
+      "overflowCountTemplate": "+ ${count} lagi ..",
       "selectAllText": "Pilih semua",
       "unSelectAllText": "Nyahpilih Semua",
-      "totalCountTemplate": "$ {count} dipilih"
+      "totalCountTemplate": "${count} dipilih"
     },
     "listbox": {
       "noRecordsTemplate": "Tiada rekod dijumpai",
@@ -2112,7 +2112,7 @@
       "noRecordsTemplate": "Tiada rekod dijumpai",
       "actionFailureTemplate": "Permintaan gagal",
       "overflowCountTemplate": "+ $ {hitung} lagi ..",
-      "totalCountTemplate": "$ {count} dipilih"
+      "totalCountTemplate": "${count} dipilih"
     },
     "documenteditor": {
       "Table": "Jadual",

--- a/src/nb.json
+++ b/src/nb.json
@@ -2111,8 +2111,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "Ingen opptak funnet",
       "actionFailureTemplate": "Forespørsel feilet",
-      "overflowCountTemplate": "+ $ {count} til ..",
-      "totalCountTemplate": "$ {count} valgt"
+      "overflowCountTemplate": "+ ${count} til ..",
+      "totalCountTemplate": "${count} valgt"
     },
     "documenteditor": {
       "Table": "Bord",

--- a/src/nl.json
+++ b/src/nl.json
@@ -2111,8 +2111,8 @@
       "drop-down-tree": {
           "noRecordsTemplate": "Geen verslagen gevonden",
           "actionFailureTemplate": "Verzoek mislukt",
-          "overflowCountTemplate": "+ $ {count} meer ...",
-          "totalCountTemplate": "$ {count} geselecteerd"
+          "overflowCountTemplate": "+ ${count} meer ...",
+          "totalCountTemplate": "${count} geselecteerd"
       },
       "documenteditor": {
           "Table": "Tabel",

--- a/src/pl.json
+++ b/src/pl.json
@@ -2111,8 +2111,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "Nic nie znaleziono",
       "actionFailureTemplate": "Żądanie nie powiodło się",
-      "overflowCountTemplate": "+ {count} $ więcej ...",
-      "totalCountTemplate": "Wybrano $ {count}"
+      "overflowCountTemplate": "+ ${count} więcej ...",
+      "totalCountTemplate": "Wybrano ${count}"
     },
     "documenteditor": {
       "Table": "Stół",

--- a/src/pt-BR.json
+++ b/src/pt-BR.json
@@ -1990,8 +1990,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "Nenhum registro foi encontrado",
       "actionFailureTemplate": "Pedido falhou",
-      "overflowCountTemplate": "+ $ {count} mais ..",
-      "totalCountTemplate": "$ {count} selecionado"
+      "overflowCountTemplate": "+ ${count} mais ..",
+      "totalCountTemplate": "${count} selecionado"
     },
     "documenteditor": {
       "Table": "Mesa",

--- a/src/pt.json
+++ b/src/pt.json
@@ -2111,8 +2111,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "Nenhum registro foi encontrado",
       "actionFailureTemplate": "Pedido falhou",
-      "overflowCountTemplate": "+ $ {count} mais ..",
-      "totalCountTemplate": "$ {count} selecionado"
+      "overflowCountTemplate": "+ ${count} mais ..",
+      "totalCountTemplate": "${count} selecionado"
     },
     "documenteditor": {
       "Table": "Mesa",

--- a/src/ro.json
+++ b/src/ro.json
@@ -2112,8 +2112,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "Nu au fost găsite",
       "actionFailureTemplate": "Cerere nereusita",
-      "overflowCountTemplate": "+ $ {count} mai mult ..",
-      "totalCountTemplate": "$ {count} selectat"
+      "overflowCountTemplate": "+ ${count} mai mult ..",
+      "totalCountTemplate": "${count} selectat"
     },
     "documenteditor": {
       "Table": "Masa",

--- a/src/ru.json
+++ b/src/ru.json
@@ -2111,8 +2111,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "записей не найдено",
       "actionFailureTemplate": "Запрос не выполнен",
-      "overflowCountTemplate": "+ еще $ {count} ..",
-      "totalCountTemplate": "Выбрано $ {count}"
+      "overflowCountTemplate": "+ еще ${count} ..",
+      "totalCountTemplate": "Выбрано ${count}"
     },
     "documenteditor": {
       "Table": "Стол",

--- a/src/sk.json
+++ b/src/sk.json
@@ -2112,7 +2112,7 @@
       "noRecordsTemplate": "Nenašli sa žiadne záznamy",
       "actionFailureTemplate": "Žiadosť zlyhala",
       "overflowCountTemplate": "+ ďalšie {$}",
-      "totalCountTemplate": "Je vybratých $ {count}"
+      "totalCountTemplate": "Je vybratých ${count}"
     },
     "documenteditor": {
       "Table": "stôl",

--- a/src/sv.json
+++ b/src/sv.json
@@ -2112,8 +2112,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "Inga uppgifter funna",
       "actionFailureTemplate": "Begäran misslyckades",
-      "overflowCountTemplate": "+ $ {count} till ..",
-      "totalCountTemplate": "$ {count} har valts"
+      "overflowCountTemplate": "+ ${count} till ..",
+      "totalCountTemplate": "${count} har valts"
     },
     "documenteditor": {
       "Table": "Tabell",

--- a/src/th.json
+++ b/src/th.json
@@ -2111,8 +2111,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "ไม่พบบันทึก",
       "actionFailureTemplate": "คำขอล้มเหลว",
-      "overflowCountTemplate": "และอีก $ {count} ..",
-      "totalCountTemplate": "เลือก $ {count}"
+      "overflowCountTemplate": "และอีก ${count} ..",
+      "totalCountTemplate": "เลือก ${count}"
     },
     "documenteditor": {
       "Table": "โต๊ะ",

--- a/src/tr.json
+++ b/src/tr.json
@@ -2111,8 +2111,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "kayıt bulunamadı",
       "actionFailureTemplate": "İstek başarısız oldu",
-      "overflowCountTemplate": "+ $ {count} tane daha ..",
-      "totalCountTemplate": "$ {count} seçildi"
+      "overflowCountTemplate": "+ ${count} tane daha ..",
+      "totalCountTemplate": "${count} seçildi"
     },
     "documenteditor": {
       "Table": "tablo",

--- a/src/vi.json
+++ b/src/vi.json
@@ -2111,8 +2111,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "Không có dữ liệu được tìm thấy",
       "actionFailureTemplate": "Yêu cầu không thành công",
-      "overflowCountTemplate": "+ $ {count} khác ..",
-      "totalCountTemplate": "$ {count} đã được chọn"
+      "overflowCountTemplate": "+ ${count} khác ..",
+      "totalCountTemplate": "${count} đã được chọn"
     },
     "documenteditor": {
       "Table": "Bàn",

--- a/src/zh.json
+++ b/src/zh.json
@@ -2113,8 +2113,8 @@
     "drop-down-tree": {
       "noRecordsTemplate": "沒有找到記錄",
       "actionFailureTemplate": "請求失敗",
-      "overflowCountTemplate": "+ $ {count}更多..",
-      "totalCountTemplate": "已選擇$ {count}個"
+      "overflowCountTemplate": "+ ${count}更多..",
+      "totalCountTemplate": "已選擇${count}個"
     },
     "documenteditor": {
       "Table": "表",


### PR DESCRIPTION
When selecting multiple items in an ejs-multiselect with Mode=CheckBox, instead of the count of selected Items, the Text '$ {count}' is displayed:
![image](https://github.com/syncfusion/ej2-locale/assets/47903283/3e496298-de6a-4482-b8af-1aa4e4c8f1c7)

The Issue is a whitespace between $ and {
