### PR TITLE
865002: Tooltip name is changed from Table Cell Vertical Align to table Vertical Align in Blazor in all language.

### DIFF
--- a/src/ar-AE.json
+++ b/src/ar-AE.json
@@ -1209,7 +1209,7 @@
       "tableRows": "صف",
       "tableColumns": "عمود",
       "tableCellHorizontalAlign": "خلية الجدول الأفقي محاذاة",
-      "tableCellVerticalAlign": "محاذاة عمودية",
+      "tableCellVerticalAlign": "المحاذاة العمودية للجدول",
       "createTable": "اصنع جدول",
       "removeTable": "إزالة الجدول",
       "tableHeader": "مقدمة الصف",

--- a/src/ar.json
+++ b/src/ar.json
@@ -1211,7 +1211,7 @@
       "tableRows": "صف",
       "tableColumns": "عمود",
       "tableCellHorizontalAlign": "خلية الجدول الأفقي محاذاة",
-      "tableCellVerticalAlign": "محاذاة عمودية",
+      "tableCellVerticalAlign": "محاذاة عمودية للجدول",
       "createTable": "اصنع جدول",
       "removeTable": "إزالة الجدول",
       "tableHeader": "مقدمة الصف",

--- a/src/cs.json
+++ b/src/cs.json
@@ -1209,7 +1209,7 @@
       "tableRows": "Řádek",
       "tableColumns": "Sloupec",
       "tableCellHorizontalAlign": "Horizontální zarovnání buňky tabulky",
-      "tableCellVerticalAlign": "Vertikální zarovnání",
+      "tableCellVerticalAlign": "Svislé zarovnání tabulky",
       "createTable": "Vytvořit tabulku",
       "removeTable": "Odebrat tabulku",
       "tableHeader": "Řádek záhlaví",

--- a/src/da.json
+++ b/src/da.json
@@ -1209,7 +1209,7 @@
       "tableRows": "Række",
       "tableColumns": "Kolonne",
       "tableCellHorizontalAlign": "Tabelcelle Vandret justering",
-      "tableCellVerticalAlign": "Lodret justering",
+      "tableCellVerticalAlign": "Tabel lodret justering",
       "createTable": "Opret tabel",
       "removeTable": "Fjern tabel",
       "tableHeader": "Overskriftsrække",

--- a/src/de.json
+++ b/src/de.json
@@ -1211,7 +1211,7 @@
       "tableRows": "Reihe",
       "tableColumns": "Spalte",
       "tableCellHorizontalAlign": "Horizontale Ausrichtung der Tabellenzelle",
-      "tableCellVerticalAlign": "Vertikal ausrichten",
+      "tableCellVerticalAlign": "Tabelle vertikal ausrichten",
       "createTable": "Tabelle erstellen",
       "removeTable": "Tabelle entfernen",
       "tableHeader": "Kopfzeile",

--- a/src/en-GB.json
+++ b/src/en-GB.json
@@ -1211,7 +1211,7 @@
             "tableRows": "Row",
             "tableColumns": "Column",
             "tableCellHorizontalAlign": "Table Cell Horizontal Align",
-            "tableCellVerticalAlign": "Vertical Align",
+            "tableCellVerticalAlign": "Table Vertical Align",
             "createTable": "Create Table",
             "removeTable": "Remove Table",
             "tableHeader": "Header Row",

--- a/src/en-US.json
+++ b/src/en-US.json
@@ -1211,7 +1211,7 @@
             "tableRows": "Row",
             "tableColumns": "Column",
             "tableCellHorizontalAlign": "Table Cell Horizontal Align",
-            "tableCellVerticalAlign": "Vertical Align",
+            "tableCellVerticalAlign": "Table Vertical Align",
             "createTable": "Create Table",
             "removeTable": "Remove Table",
             "tableHeader": "Header Row",

--- a/src/es.json
+++ b/src/es.json
@@ -1211,7 +1211,7 @@
       "tableRows": "Fila",
       "tableColumns": "Columna",
       "tableCellHorizontalAlign": "Alineación horizontal de celda de tabla",
-      "tableCellVerticalAlign": "Alineación vertical",
+      "tableCellVerticalAlign": "Alineación vertical de mesa",
       "createTable": "Crear mesa",
       "removeTable": "Eliminar tabla",
       "tableHeader": "Fila de encabezado",

--- a/src/fa.json
+++ b/src/fa.json
@@ -1209,7 +1209,7 @@
       "tableRows": "ردیف",
       "tableColumns": "ستون",
       "tableCellHorizontalAlign": "جدول سلول تراز افقی",
-      "tableCellVerticalAlign": "تراز عمودی",
+      "tableCellVerticalAlign": "تراز عمودی جدول",
       "createTable": "ایجاد جدول",
       "removeTable": "حذف جدول",
       "tableHeader": "ردیف سرصفحه",

--- a/src/fi.json
+++ b/src/fi.json
@@ -1209,7 +1209,7 @@
       "tableRows": "Rivi",
       "tableColumns": "Sarake",
       "tableCellHorizontalAlign": "Pöytäsolujen vaakasuuntainen kohdistus",
-      "tableCellVerticalAlign": "Pystysuuntainen tasaus",
+      "tableCellVerticalAlign": "Taulukon pystytasaus",
       "createTable": "Luo taulukko",
       "removeTable": "Poista taulukko",
       "tableHeader": "Otsikkorivi",

--- a/src/fr.json
+++ b/src/fr.json
@@ -1211,7 +1211,7 @@
       "tableRows": "Rangée",
       "tableColumns": "Colonne",
       "tableCellHorizontalAlign": "Alignement horizontal des cellules du tableau",
-      "tableCellVerticalAlign": "Alignement vertical",
+      "tableCellVerticalAlign": "Alignement vertical du tableau",
       "createTable": "Créer une table",
       "removeTable": "Supprimer le tableau",
       "tableHeader": "Ligne d'en-tête",

--- a/src/he.json
+++ b/src/he.json
@@ -1209,7 +1209,7 @@
       "tableRows": "שׁוּרָה",
       "tableColumns": "טור",
       "tableCellHorizontalAlign": "יישור אופקי של תא שולחן",
-      "tableCellVerticalAlign": "יישור אנכי",
+      "tableCellVerticalAlign": "טבלת יישור אנכיתי",
       "createTable": "צור טבלה",
       "removeTable": "הסר את הטבלה",
       "tableHeader": "שורת כותרת",

--- a/src/hr.json
+++ b/src/hr.json
@@ -1209,7 +1209,7 @@
       "tableRows": "Red",
       "tableColumns": "Stupac",
       "tableCellHorizontalAlign": "Vodoravno poravnavanje ćelije tablice",
-      "tableCellVerticalAlign": "Okomito poravnanje",
+      "tableCellVerticalAlign": "Okomito poravnanje tablice",
       "createTable": "Stvori tablicu",
       "removeTable": "Ukloni tablicu",
       "tableHeader": "Redak zaglavlja",

--- a/src/hu.json
+++ b/src/hu.json
@@ -1209,7 +1209,7 @@
       "tableRows": "Sor",
       "tableColumns": "Oszlop",
       "tableCellHorizontalAlign": "Táblázat cella vízszintes igazítása",
-      "tableCellVerticalAlign": "Függőleges igazítás",
+      "tableCellVerticalAlign": "Táblázat függőleges igazítása",
       "createTable": "Táblázat létrehozása",
       "removeTable": "Táblázat eltávolítása",
       "tableHeader": "Fejléc sor",

--- a/src/id.json
+++ b/src/id.json
@@ -1209,7 +1209,7 @@
       "tableRows": "Baris",
       "tableColumns": "Kolom",
       "tableCellHorizontalAlign": "Perataan Horisontal Sel Tabel",
-      "tableCellVerticalAlign": "Perataan Vertikal",
+      "tableCellVerticalAlign": "Tabel Vertikal Sejajar",
       "createTable": "Buat tabel",
       "removeTable": "Hapus Table",
       "tableHeader": "Baris Tajuk",

--- a/src/is.json
+++ b/src/is.json
@@ -1157,7 +1157,7 @@
       "tableRows": "Röð",
       "tableColumns": "Dálkur",
       "tableCellHorizontalAlign": "Lárétt jöfnun töflufruma",
-      "tableCellVerticalAlign": "Lóðrétt stilla",
+      "tableCellVerticalAlign": "Tafla lóðrétt Jafna",
       "createTable": "Búa til töflu",
       "removeTable": "Fjarlægja töflu",
       "tableHeader": "Hausaröð",

--- a/src/it.json
+++ b/src/it.json
@@ -1209,7 +1209,7 @@
       "tableRows": "Riga",
       "tableColumns": "Colonna",
       "tableCellHorizontalAlign": "Allinea orizzontale cella cella",
-      "tableCellVerticalAlign": "Allineamento verticale",
+      "tableCellVerticalAlign": "Allineamento verticale della tabella",
       "createTable": "Crea tabella",
       "removeTable": "Rimuovi tabella",
       "tableHeader": "Riga di intestazione",

--- a/src/ja.json
+++ b/src/ja.json
@@ -1209,7 +1209,7 @@
       "tableRows": "行",
       "tableColumns": "カラム",
       "tableCellHorizontalAlign": "テーブルセルの水平方向の整列",
-      "tableCellVerticalAlign": "垂直方向の整列",
+      "tableCellVerticalAlign": "テーブルの垂直方向の配置",
       "createTable": "テーブルを作成",
       "removeTable": "テーブルを削除",
       "tableHeader": "ヘッダー行",

--- a/src/ko.json
+++ b/src/ko.json
@@ -1209,7 +1209,7 @@
       "tableRows": "열",
       "tableColumns": "열",
       "tableCellHorizontalAlign": "테이블 셀 가로 정렬",
-      "tableCellVerticalAlign": "수직 정렬",
+      "tableCellVerticalAlign": "테이블 수직 정렬",
       "createTable": "테이블 만들기",
       "removeTable": "테이블 제거",
       "tableHeader": "헤더 행",

--- a/src/ms.json
+++ b/src/ms.json
@@ -1209,7 +1209,7 @@
       "tableRows": "baris",
       "tableColumns": "Kolum",
       "tableCellHorizontalAlign": "Jadual Sel Aligning Align",
-      "tableCellVerticalAlign": "Jajaran Menegak",
+      "tableCellVerticalAlign": "Jadual Menegak ALalign",
       "createTable": "Buat Jadual",
       "removeTable": "Buang Jadual",
       "tableHeader": "Baris Pengepala",

--- a/src/nb.json
+++ b/src/nb.json
@@ -1209,7 +1209,7 @@
       "tableRows": "Rad",
       "tableColumns": "Kolonne",
       "tableCellHorizontalAlign": "Tabellcelle Horisontal justering",
-      "tableCellVerticalAlign": "Vertikal justering",
+      "tableCellVerticalAlign": "Tabell Vertical Align",
       "createTable": "Lag tabell",
       "removeTable": "Fjern tabellen",
       "tableHeader": "Overskriftsrad",

--- a/src/nl.json
+++ b/src/nl.json
@@ -1209,7 +1209,7 @@
           "tableRows": "Fila",
           "tableColumns": "Columna",
           "tableCellHorizontalAlign": "Tabelcel Horizontaal uitlijnen",
-          "tableCellVerticalAlign": "Alineación vertical",
+          "tableCellVerticalAlign": "Alineación vertical de la tabla",
           "createTable": "Maak een tabel aan",
           "removeTable": "Verwijder tabel",
           "tableHeader": "Fila de encabezado",

--- a/src/pl.json
+++ b/src/pl.json
@@ -1209,7 +1209,7 @@
       "tableRows": "Wiersz",
       "tableColumns": "Kolumna",
       "tableCellHorizontalAlign": "Tabela komórek Wyrównanie w poziomie",
-      "tableCellVerticalAlign": "Wyrównanie w pionie",
+      "tableCellVerticalAlign": "Wyrównanie w pionie tabeli",
       "createTable": "Utwórz tabelę",
       "removeTable": "Usuń tabelę",
       "tableHeader": "Wiersz nagłówka",

--- a/src/pt-BR.json
+++ b/src/pt-BR.json
@@ -1209,7 +1209,7 @@
       "tableRows": "Linha",
       "tableColumns": "Coluna",
       "tableCellHorizontalAlign": "Alinhamento horizontal da célula da tabela",
-      "tableCellVerticalAlign": "Alinhamento vertical",
+      "tableCellVerticalAlign": "Alinhamento Vertical da Tabela",
       "createTable": "Criar a tabela",
       "removeTable": "Remover tabela",
       "tableHeader": "Linha de cabeçalho",

--- a/src/pt.json
+++ b/src/pt.json
@@ -1209,7 +1209,7 @@
       "tableRows": "Linha",
       "tableColumns": "Coluna",
       "tableCellHorizontalAlign": "Alinhamento horizontal da célula da tabela",
-      "tableCellVerticalAlign": "Alinhamento vertical",
+      "tableCellVerticalAlign": "Alinhamento vertical da tabela",
       "createTable": "Criar a tabela",
       "removeTable": "Remover tabela",
       "tableHeader": "Linha de cabeçalho",

--- a/src/ro.json
+++ b/src/ro.json
@@ -1209,7 +1209,7 @@
       "tableRows": "Rând",
       "tableColumns": "Coloană",
       "tableCellHorizontalAlign": "Aliniere orizontală a celulelor de masă",
-      "tableCellVerticalAlign": "Aliniere verticală",
+      "tableCellVerticalAlign": "Aliniere verticală a tabelului",
       "createTable": "Creare tabel",
       "removeTable": "Eliminați tabelul",
       "tableHeader": "Rând antet",

--- a/src/ru.json
+++ b/src/ru.json
@@ -1209,7 +1209,7 @@
       "tableRows": "Ряд",
       "tableColumns": "Столбец",
       "tableCellHorizontalAlign": "Горизонтальное выравнивание ячейки таблицы",
-      "tableCellVerticalAlign": "Вертикальное выравнивание",
+      "tableCellVerticalAlign": "Таблица по вертикали",
       "createTable": "Создать таблицу",
       "removeTable": "Удалить таблицу",
       "tableHeader": "Заголовок строки",

--- a/src/sk.json
+++ b/src/sk.json
@@ -1209,7 +1209,7 @@
       "tableRows": "riadok",
       "tableColumns": "Stĺpec",
       "tableCellHorizontalAlign": "Horizontálne zarovnanie bunky tabuľky",
-      "tableCellVerticalAlign": "Vertikálne zarovnanie",
+      "tableCellVerticalAlign": "Tabuľka VERtical ALign",
       "createTable": "Vytvorenie tabuľky",
       "removeTable": "Odstráňte tabuľku",
       "tableHeader": "Riadok hlavičky",

--- a/src/sv.json
+++ b/src/sv.json
@@ -1209,7 +1209,7 @@
       "tableRows": "Rad",
       "tableColumns": "Kolumn",
       "tableCellHorizontalAlign": "Tabellcells horisontell justering",
-      "tableCellVerticalAlign": "Vertikal justering",
+      "tableCellVerticalAlign": "Tabell Vertikal Align",
       "createTable": "Skapa bord",
       "removeTable": "Ta bort tabellen",
       "tableHeader": "Rubrikrad",

--- a/src/th.json
+++ b/src/th.json
@@ -1209,7 +1209,7 @@
       "tableRows": "แถว",
       "tableColumns": "คอลัมน์",
       "tableCellHorizontalAlign": "จัดเรียงแนวนอนของเซลล์ตาราง",
-      "tableCellVerticalAlign": "จัดแนวตั้ง",
+      "tableCellVerticalAlign": "จัดตำแหน่งตารางแนวตั้ง",
       "createTable": "สร้างตาราง",
       "removeTable": "ลบตาราง",
       "tableHeader": "แถวส่วนหัว",

--- a/src/tr.json
+++ b/src/tr.json
@@ -1209,7 +1209,7 @@
       "tableRows": "Sıra",
       "tableColumns": "Kolon",
       "tableCellHorizontalAlign": "Tablo Hücresi Yatay Hizalama",
-      "tableCellVerticalAlign": "Dikey Hizalama",
+      "tableCellVerticalAlign": "Tablo Dikey Hizalama",
       "createTable": "Tablo Oluştur",
       "removeTable": "Tabloyu Kaldır",
       "tableHeader": "Üst bilgi satırı",

--- a/src/vi.json
+++ b/src/vi.json
@@ -1209,7 +1209,7 @@
       "tableRows": "Hàng ngang",
       "tableColumns": "Cột",
       "tableCellHorizontalAlign": "Bảng di động ngang",
-      "tableCellVerticalAlign": "Căn dọc",
+      "tableCellVerticalAlign": "Căn chỉnh bảng theo chiều dọc",
       "createTable": "Tạo bảng",
       "removeTable": "Xóa bảng",
       "tableHeader": "Dòng tiêu đề",

--- a/src/zh.json
+++ b/src/zh.json
@@ -1211,7 +1211,7 @@
       "tableRows": "排",
       "tableColumns": "柱子",
       "tableCellHorizontalAlign": "表格單元格水平對齊",
-      "tableCellVerticalAlign": "垂直对齐",
+      "tableCellVerticalAlign": "表格垂直对齐",
       "createTable": "建立表格",
       "removeTable": "刪除表",
       "tableHeader": "标题行",


### PR DESCRIPTION
### Bug description
Correct the tooltip text for table vertical align in table quick toolbar
                
### Root Cause / Analysis
Tooltip text was named incorrectly. 
                
### Reason for not identifying earlier
This particular use case is not tested or considered when development
                
### Is Breaking issue.?
No

### Is reported by customer in incident/forum.?

No

### Solution Description
• Checked where the tooptip exists in source code 
• Change the tooltip text in  in all language in locale 

### Areas affected and ensured
NA

### E2E report details against this fix
NA

### Did you included unit test cases.?

No

### Is there any API name changes.?

No

/label ~bug
/assign @ScrumMaster
/cc @ProductOwner
