### PR TITLE
868490: Accessibility issue with checkbox in Accessibility Insights for web tool.

### DIFF
--- a/src/ar-AE.json
+++ b/src/ar-AE.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "خانة الاختيار",
       "Expanded": "موسع",
       "Collapsed": "انهار",
-      "SelectAllCheckbox": "حدد خانة الاختيار الكل"
+      "SelectAllCheckbox": "حدد خانة الاختيار الكل",
+      "SelectRow": "حدد الصف"
     },
     "pager": {
       "currentPageInfo": "{0} من {1} صفحة",

--- a/src/ar.json
+++ b/src/ar.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "خانة الاختيار",
       "Expanded": "موسع",
       "Collapsed": "انهار",
-      "SelectAllCheckbox": "حدد خانة الاختيار الكل"
+      "SelectAllCheckbox": "حدد خانة الاختيار الكل",
+      "SelectRow": "حدد الصف"
     },
     "pager": {
       "currentPageInfo": "{0} من {1} صفحة",

--- a/src/cs.json
+++ b/src/cs.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "zaškrtávací políčko",
       "Expanded": "Rozšířený",
       "Collapsed": "Zhroucený",
-      "SelectAllCheckbox": "Zaškrtněte políčko Vše"
+      "SelectAllCheckbox": "Zaškrtněte políčko Vše",
+      "SelectRow": "Vyberte řádek"
     },
     "pager": {
       "currentPageInfo": "{0} z {1} stránek",

--- a/src/da.json
+++ b/src/da.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "afkrydsningsfeltet",
       "Expanded": "Udvidet",
       "Collapsed": "Kollapsede",
-      "SelectAllCheckbox": "Marker afkrydsningsfeltet Alle"
+      "SelectAllCheckbox": "Marker afkrydsningsfeltet Alle",
+      "SelectRow": "Vælg række"
     },
     "pager": {
       "currentPageInfo": "{0} af {1} sider",

--- a/src/de.json
+++ b/src/de.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "Kontrollkästchen",
       "Expanded": "Erweitert",
       "Collapsed": "Zusammengebrochen",
-      "SelectAllCheckbox": "Kontrollkästchen „Alle auswählen“."
+      "SelectAllCheckbox": "Kontrollkästchen „Alle auswählen“.",
+      "SelectRow": "Zeile auswählen"
     },
     "pager": {
       "currentPageInfo": "{0} von {1} Seiten",

--- a/src/en-GB.json
+++ b/src/en-GB.json
@@ -130,7 +130,8 @@
             "CheckBoxLabel": "checkbox",
             "Expanded": "Expanded",
             "Collapsed": "Collapsed",
-            "SelectAllCheckbox": "Select all checkbox"
+            "SelectAllCheckbox": "Select all checkbox",
+            "SelectRow": "Select row"
         },
         "pager": {
             "currentPageInfo": "{0} of {1} pages",

--- a/src/en-US.json
+++ b/src/en-US.json
@@ -130,7 +130,8 @@
             "CheckBoxLabel": "checkbox",
             "Expanded": "Expanded",
             "Collapsed": "Collapsed",
-            "SelectAllCheckbox": "Select all checkbox"
+            "SelectAllCheckbox": "Select all checkbox",
+            "SelectRow": "Select row"
         },
         "pager": {
             "currentPageInfo": "{0} of {1} pages",

--- a/src/es.json
+++ b/src/es.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "casilla de verificación",
       "Expanded": "Expandida",
       "Collapsed": "Contraída",
-      "SelectAllCheckbox": "Seleccionar todo Casilla de verificación"
+      "SelectAllCheckbox": "Seleccionar todo Casilla de verificación",
+      "SelectRow": "Seleccionar fila"
     },
     "pager": {
       "currentPageInfo": "{0} de {1} páginas",

--- a/src/fa.json
+++ b/src/fa.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "چک باکس",
       "Expanded": "منبسط",
       "Collapsed": "فرو ریخت",
-      "SelectAllCheckbox": "همه کادر را انتخاب کنید"
+      "SelectAllCheckbox": "همه کادر را انتخاب کنید",
+      "SelectRow": "ردیف را انتخاب کنید"
     },
     "pager": {
       "currentPageInfo": "{0} از 1 {صفحه",

--- a/src/fi.json
+++ b/src/fi.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "valintaruutu",
       "Expanded": "Laajennettu",
       "Collapsed": "Romahtanut",
-      "SelectAllCheckbox": "Valitse Kaikki -valintaruutu"
+      "SelectAllCheckbox": "Valitse Kaikki -valintaruutu",
+      "SelectRow": "Valitse rivi"
     },
     "pager": {
       "currentPageInfo": "{0} {1} sivusta",

--- a/src/fr.json
+++ b/src/fr.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "case à cocher",
       "Expanded": "Étendue",
       "Collapsed": "S'est effondré",
-      "SelectAllCheckbox": "Case à cocher Sélectionner tout"
+      "SelectAllCheckbox": "Case à cocher Sélectionner tout",
+      "SelectRow": "Sélectionner une ligne"
     },
     "pager": {
       "currentPageInfo": "{0} de {1} pages",

--- a/src/he.json
+++ b/src/he.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "תיבת סימון",
       "Expanded": "מוּרחָב",
       "Collapsed": "תצוגה מכווצת",
-      "SelectAllCheckbox": "בחר תיבת סימון הכל"
+      "SelectAllCheckbox": "בחר תיבת סימון הכל",
+      "SelectRow": "בחר שורה"
     },
     "pager": {
       "currentPageInfo": "{0} מתוך {1} עמודים",

--- a/src/hr.json
+++ b/src/hr.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "potvrdni okvir",
       "Expanded": "Prošireno",
       "Collapsed": "Srušeno",
-      "SelectAllCheckbox": "Odaberite potvrdni okvir Sve"
+      "SelectAllCheckbox": "Odaberite potvrdni okvir Sve",
+      "SelectRow": "Odaberite red"
     },
     "pager": {
       "currentPageInfo": "{0} od {1} stranica",

--- a/src/hu.json
+++ b/src/hu.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "jelölőnégyzetet",
       "Expanded": "Kiterjesztett",
       "Collapsed": "Összeomlott",
-      "SelectAllCheckbox": "Jelölje be az Összes jelölőnégyzetet"
+      "SelectAllCheckbox": "Jelölje be az Összes jelölőnégyzetet",
+      "SelectRow": "Válassza ki a sort"
     },
     "pager": {
       "currentPageInfo": "{1} oldal {0}",

--- a/src/id.json
+++ b/src/id.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "kotak centang",
       "Expanded": "Diperluas",
       "Collapsed": "Runtuh",
-      "SelectAllCheckbox": "Pilih Semua Kotak Centang"
+      "SelectAllCheckbox": "Pilih Semua Kotak Centang",
+      "SelectRow": "Pilih baris"
     },
     "pager": {
       "currentPageInfo": "{0} dari {1} halaman",

--- a/src/is.json
+++ b/src/is.json
@@ -85,7 +85,8 @@
       "AND": "OG",
       "OR": "EÐA",
       "ShowRowsWhere": "Sýna línur þar sem:",
-      "SelectAllCheckbox": "Veldu allt gátreit"
+      "SelectAllCheckbox": "Veldu allt gátreit",
+      "SelectRow": "Veldu röð"
     },
     "pager": {
       "currentPageInfo": "{0} af {1} síðum",

--- a/src/it.json
+++ b/src/it.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "casella di controllo",
       "Expanded": "Allargata",
       "Collapsed": "Crollato",
-      "SelectAllCheckbox": "Seleziona la casella di controllo Tutto"
+      "SelectAllCheckbox": "Seleziona la casella di controllo Tutto",
+      "SelectRow": "Seleziona riga"
     },
     "pager": {
       "currentPageInfo": "{0} di {1} pagine",

--- a/src/ja.json
+++ b/src/ja.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "チェックボックス",
       "Expanded": "エキスパンド",
       "Collapsed": "折りたたまれた",
-      "SelectAllCheckbox": "すべて選択チェックボックス"
+      "SelectAllCheckbox": "すべて選択チェックボックス",
+      "SelectRow": "行を選択"
     },
     "pager": {
       "currentPageInfo": "{0}ページのうち{1}ページ",

--- a/src/ko.json
+++ b/src/ko.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "체크박스",
       "Expanded": "퍼지는",
       "Collapsed": "축소됨",
-      "SelectAllCheckbox": "모든 체크박스 선택"
+      "SelectAllCheckbox": "모든 체크박스 선택",
+      "SelectRow": "행 선택"
     },
     "pager": {
       "currentPageInfo": "{1} 페이지 중 {0}",

--- a/src/ms.json
+++ b/src/ms.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "kotak centang",
       "Expanded": "Diperluas",
       "Collapsed": "Runtuh",
-      "SelectAllCheckbox": "Pilih Semua Kotak Semak"
+      "SelectAllCheckbox": "Pilih Semua Kotak Semak",
+      "SelectRow": "Pilih baris"
     },
     "pager": {
       "currentPageInfo": "{0} halaman {1}",

--- a/src/nb.json
+++ b/src/nb.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "avmerkingsboksen",
       "Expanded": "Utvidet",
       "Collapsed": "Kollapset",
-      "SelectAllCheckbox": "Merk av for Alle"
+      "SelectAllCheckbox": "Merk av for Alle",
+      "SelectRow": "Velg rad"
     },
     "pager": {
       "currentPageInfo": "{0} av {1} sider",

--- a/src/ne-NP.json
+++ b/src/ne-NP.json
@@ -130,7 +130,8 @@
             "CheckBoxLabel": "चेकबक्स",
             "Expanded": "विस्तार गरियो",
             "Collapsed": "संक्षिप्त गरियो",
-            "SelectAllCheckbox": "सबै चेकबक्स चयन गर्नुहोस्"
+            "SelectAllCheckbox": "सबै चेकबक्स चयन गर्नुहोस्",
+            "SelectRow": "पङ्क्ति चयन गर्नुहोस्"
         },
         "pager": {
             "currentPageInfo": "{1} पृष्ठहरू मध्ये {0}",

--- a/src/nl.json
+++ b/src/nl.json
@@ -130,7 +130,8 @@
           "CheckBoxLabel": "selectievakje",
           "Expanded": "uitgebreid",
           "Collapsed": "Ingestort",
-          "SelectAllCheckbox": "Selecteer Alles"
+          "SelectAllCheckbox": "Selecteer Alles",
+          "SelectRow": "Selecteer rij"
       },
       "pager": {
           "currentPageInfo": "{0} van {1} pagina's",

--- a/src/pl.json
+++ b/src/pl.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "pole wyboru",
       "Expanded": "Rozszerzony",
       "Collapsed": "Zwinięty",
-      "SelectAllCheckbox": "Zaznacz pole wyboru Wszystkie"
+      "SelectAllCheckbox": "Zaznacz pole wyboru Wszystkie",
+      "SelectRow": "Wybierz wiersz"
     },
     "pager": {
       "currentPageInfo": "{0} z {1} stron",

--- a/src/pt-BR.json
+++ b/src/pt-BR.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "caixa de seleção",
       "Expanded": "Expandida",
       "Collapsed": "Desabou",
-      "SelectAllCheckbox": "Caixa de seleção Selecionar tudo"
+      "SelectAllCheckbox": "Caixa de seleção Selecionar tudo",
+      "SelectRow": "Selecione a linha"
     },
     "pager": {
       "currentPageInfo": "{0} de {1} páginas",

--- a/src/pt.json
+++ b/src/pt.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "caixa de seleção",
       "Expanded": "Expandida",
       "Collapsed": "Desabou",
-      "SelectAllCheckbox": "Caixa de seleção Selecionar tudo"
+      "SelectAllCheckbox": "Caixa de seleção Selecionar tudo",
+      "SelectRow": "Selecione a linha"
     },
     "pager": {
       "currentPageInfo": "{0} de {1} páginas",

--- a/src/ro.json
+++ b/src/ro.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "Caseta de bifat",
       "Expanded": "Extins",
       "Collapsed": "S-a prăbușit",
-      "SelectAllCheckbox": "Selectați caseta de selectare Toate"
+      "SelectAllCheckbox": "Selectați caseta de selectare Toate",
+      "SelectRow": "Selectați rândul"
     },
     "pager": {
       "currentPageInfo": "{0} din {1} pagini",

--- a/src/ru.json
+++ b/src/ru.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "флажок",
       "Expanded": "Расширенный",
       "Collapsed": "Свернуто",
-      "SelectAllCheckbox": "Флажок «Выбрать все»"
+      "SelectAllCheckbox": "Флажок «Выбрать все»",
+      "SelectRow": "Выберите строку"
     },
     "pager": {
       "currentPageInfo": "{0} из {1} страниц",

--- a/src/sk.json
+++ b/src/sk.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "zaškrtávací políčko",
       "Expanded": "Rozšírené",
       "Collapsed": "Zrútené",
-      "SelectAllCheckbox": "Začiarknite políčko Všetky"
+      "SelectAllCheckbox": "Začiarknite políčko Všetky",
+      "SelectRow": "Vyberte riadok"
     },
     "pager": {
       "currentPageInfo": "{0} z {1} stránok",

--- a/src/sv.json
+++ b/src/sv.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "kryssruta",
       "Expanded": "Expanderat",
       "Collapsed": "Kollapsade",
-      "SelectAllCheckbox": "Markera kryssrutan Alla"
+      "SelectAllCheckbox": "Markera kryssrutan Alla",
+      "SelectRow": "Välj rad"
     },
     "pager": {
       "currentPageInfo": "{0} av {1} sidor",

--- a/src/th.json
+++ b/src/th.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "ช่องทำเครื่องหมาย",
       "Expanded": "ขยาย",
       "Collapsed": "ยุบ",
-      "SelectAllCheckbox": "เลือกช่องทำเครื่องหมายทั้งหมด"
+      "SelectAllCheckbox": "เลือกช่องทำเครื่องหมายทั้งหมด",
+      "SelectRow": "เลือกแถว"
     },
     "pager": {
       "currentPageInfo": "หน้า {0} จาก {1} หน้า",

--- a/src/tr.json
+++ b/src/tr.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "onay kutusu",
       "Expanded": "Genişletilmiş",
       "Collapsed": "çöktü",
-      "SelectAllCheckbox": "Tümünü Seç Onay Kutusu"
+      "SelectAllCheckbox": "Tümünü Seç Onay Kutusu",
+      "SelectRow": "Satır seç"
     },
     "pager": {
       "currentPageInfo": "{1} sayfanın {0}",

--- a/src/vi.json
+++ b/src/vi.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "hộp kiểm",
       "Expanded": "mở rộng",
       "Collapsed": "Đã thu gọn",
-      "SelectAllCheckbox": "Chọn tất cả hộp kiểm"
+      "SelectAllCheckbox": "Chọn tất cả hộp kiểm",
+      "SelectRow": "Chọn hàng"
     },
     "pager": {
       "currentPageInfo": "{0} trong số {1} trang",

--- a/src/zh.json
+++ b/src/zh.json
@@ -130,7 +130,8 @@
       "CheckBoxLabel": "复选框",
       "Expanded": "展开",
       "Collapsed": "倒塌",
-      "SelectAllCheckbox": "选择全部复选框"
+      "SelectAllCheckbox": "选择全部复选框",
+      "SelectRow": "选择行"
     },
     "pager": {
       "currentPageInfo": "第{0}頁／共{1}頁",


### PR DESCRIPTION
### Bug description

Accessibility issue with checkbox in Accessibility Insights for web tool.

### Root cause

aria-label property for that checkbox element is not provided while rendering in grid.

### Reason for not identifying earlier

Find how it was missed in our earlier testing and development by analyzing the below checklist. This will help prevent similar mistakes in the future.

- [ ] Guidelines/documents are not followed

- Common guidelines / Core team guideline

- Specification document

- Requirement document

- [x] Guidelines/documents are not given

- Common guidelines / Core team guideline

- Specification document

- Requirement document

### Reason:

Guidelines/documents are not given - Requirement document

### Action taken:

Not Applicable. Manually tested with local sample with `Accessibility Insights for Web`.

### Related areas:

locale, grid and cell renderer file.

### Is it a breaking issue?

No.

### Solution description

Properly aria-label property for that checkbox element is provided while rendering in grid.

### Output screenshots

withoutfix:
![image](https://github.com/essential-studio/ej2-grid-components/assets/100338903/eb70cc04-6e09-4571-a261-d5019347f10b)

withfix:
![image](https://github.com/essential-studio/ej2-grid-components/assets/100338903/0f2baab3-64d0-4a9c-be86-fa24ef7ee854)

![image](https://github.com/essential-studio/ej2-grid-components/assets/100338903/3557c867-15d8-4965-bf99-6b6169c5baab)

### Areas affected and ensured

Screen reader like JAWS, NVDA and microsoft narrator and `Accessibility Insights for Web` tool in chrome browser.

### Additional checklist

This may vary for different teams or products. Check with your scrum masters.

- Did you run the automation against your fix? - Yes.

- Is there any API name change? - No

- Is there any existing behavior change of other features due to this code change? - No

- Does your new code introduce new warnings or binding errors? - No

- Does your code pass all FxCop and StyleCop rules? a- No

- Did you record this case in the unit test or UI test? - No.
