### PR TITLE
902193: Localization doesn't work for sorting buttons in adaptiveUI

### DIFF
--- a/src/ar-AE.json
+++ b/src/ar-AE.json
@@ -131,7 +131,10 @@
       "Expanded": "موسع",
       "Collapsed": "انهار",
       "SelectAllCheckbox": "حدد خانة الاختيار الكل",
-      "SelectRow": "حدد الصف"
+      "SelectRow": "حدد الصف",
+      "AscendingText": "تصاعدي",
+      "DescendingText": "تنازلي ",
+      "NoneText": "لا شيء"
     },
     "pager": {
       "currentPageInfo": "{0} من {1} صفحة",

--- a/src/ar.json
+++ b/src/ar.json
@@ -131,7 +131,10 @@
       "Expanded": "موسع",
       "Collapsed": "انهار",
       "SelectAllCheckbox": "حدد خانة الاختيار الكل",
-      "SelectRow": "حدد الصف"
+      "SelectRow": "حدد الصف",
+      "AscendingText": "تصاعدي",
+      "DescendingText": "تنازلي ",
+      "NoneText": "لا شيء"
     },
     "pager": {
       "currentPageInfo": "{0} من {1} صفحة",

--- a/src/cs.json
+++ b/src/cs.json
@@ -131,7 +131,10 @@
       "Expanded": "Rozšířený",
       "Collapsed": "Zhroucený",
       "SelectAllCheckbox": "Zaškrtněte políčko Vše",
-      "SelectRow": "Vyberte řádek"
+      "SelectRow": "Vyberte řádek",
+      "AscendingText": "Vzestupně",
+      "DescendingText": "Sestupně",
+      "NoneText": "Žádný"
     },
     "pager": {
       "currentPageInfo": "{0} z {1} stránek",

--- a/src/da.json
+++ b/src/da.json
@@ -131,7 +131,10 @@
       "Expanded": "Udvidet",
       "Collapsed": "Kollapsede",
       "SelectAllCheckbox": "Marker afkrydsningsfeltet Alle",
-      "SelectRow": "Vælg række"
+      "SelectRow": "Vælg række",
+      "AscendingText": "Stigende",
+      "DescendingText": "Faldende",
+      "NoneText": "Ingen"
     },
     "pager": {
       "currentPageInfo": "{0} af {1} sider",

--- a/src/de.json
+++ b/src/de.json
@@ -131,7 +131,10 @@
       "Expanded": "Erweitert",
       "Collapsed": "Zusammengebrochen",
       "SelectAllCheckbox": "Kontrollkästchen „Alle auswählen“.",
-      "SelectRow": "Zeile auswählen"
+      "SelectRow": "Zeile auswählen",
+      "AscendingText": "Aufsteigend",
+      "DescendingText": "Absteigend",
+      "NoneText": "Keine"
     },
     "pager": {
       "currentPageInfo": "{0} von {1} Seiten",

--- a/src/en-GB.json
+++ b/src/en-GB.json
@@ -131,7 +131,10 @@
       "Expanded": "Expanded",
       "Collapsed": "Collapsed",
       "SelectAllCheckbox": "Select all checkbox",
-      "SelectRow": "Select row"
+      "SelectRow": "Select row",
+      "AscendingText": "Ascending",
+      "DescendingText": "Descending",
+      "NoneText": "None"
     },
     "pager": {
       "currentPageInfo": "{0} of {1} pages",

--- a/src/en-US.json
+++ b/src/en-US.json
@@ -131,7 +131,10 @@
       "Expanded": "Expanded",
       "Collapsed": "Collapsed",
       "SelectAllCheckbox": "Select all checkbox",
-      "SelectRow": "Select row"
+      "SelectRow": "Select row",
+      "AscendingText": "Ascending",
+      "DescendingText": "Descending",
+      "NoneText": "None"
     },
     "pager": {
       "currentPageInfo": "{0} of {1} pages",

--- a/src/es.json
+++ b/src/es.json
@@ -131,7 +131,10 @@
       "Expanded": "Expandida",
       "Collapsed": "Contraída",
       "SelectAllCheckbox": "Seleccionar todo Casilla de verificación",
-      "SelectRow": "Seleccionar fila"
+      "SelectRow": "Seleccionar fila",
+      "AscendingText": "Ascendente",
+      "DescendingText": "Descendente",
+      "NoneText": "Ninguno"
     },
     "pager": {
       "currentPageInfo": "{0} de {1} páginas",

--- a/src/fa.json
+++ b/src/fa.json
@@ -131,7 +131,10 @@
       "Expanded": "منبسط",
       "Collapsed": "فرو ریخت",
       "SelectAllCheckbox": "همه کادر را انتخاب کنید",
-      "SelectRow": "ردیف را انتخاب کنید"
+      "SelectRow": "ردیف را انتخاب کنید",
+      "AscendingText": "صعودی",
+      "DescendingText": "نزولی",
+      "NoneText": "هیچ"
     },
     "pager": {
       "currentPageInfo": "{0} از 1 {صفحه",

--- a/src/fi.json
+++ b/src/fi.json
@@ -131,7 +131,10 @@
       "Expanded": "Laajennettu",
       "Collapsed": "Romahtanut",
       "SelectAllCheckbox": "Valitse Kaikki -valintaruutu",
-      "SelectRow": "Valitse rivi"
+      "SelectRow": "Valitse rivi",
+      "AscendingText": "Nouseva",
+      "DescendingText": "Laskeva",
+      "NoneText": "Ei mitään"
     },
     "pager": {
       "currentPageInfo": "{0} {1} sivusta",

--- a/src/fr.json
+++ b/src/fr.json
@@ -131,7 +131,10 @@
       "Expanded": "Étendue",
       "Collapsed": "S'est effondré",
       "SelectAllCheckbox": "Case à cocher Sélectionner tout",
-      "SelectRow": "Sélectionner une ligne"
+      "SelectRow": "Sélectionner une ligne",
+      "AscendingText": "Ascendant",
+      "DescendingText": "Descendant",
+      "NoneText": "Aucun"
     },
     "pager": {
       "currentPageInfo": "{0} de {1} pages",

--- a/src/he.json
+++ b/src/he.json
@@ -131,7 +131,10 @@
       "Expanded": "מוּרחָב",
       "Collapsed": "תצוגה מכווצת",
       "SelectAllCheckbox": "בחר תיבת סימון הכל",
-      "SelectRow": "בחר שורה"
+      "SelectRow": "בחר שורה",
+      "AscendingText": "עולה",
+      "DescendingText": "יורד",
+      "NoneText": "אין"
     },
     "pager": {
       "currentPageInfo": "{0} מתוך {1} עמודים",

--- a/src/hr.json
+++ b/src/hr.json
@@ -131,7 +131,10 @@
       "Expanded": "Prošireno",
       "Collapsed": "Srušeno",
       "SelectAllCheckbox": "Odaberite potvrdni okvir Sve",
-      "SelectRow": "Odaberite red"
+      "SelectRow": "Odaberite red",
+      "AscendingText": "Rastući",
+      "DescendingText": "Opadajući",
+      "NoneText": "Niti jedan"
     },
     "pager": {
       "currentPageInfo": "{0} od {1} stranica",

--- a/src/hu.json
+++ b/src/hu.json
@@ -131,7 +131,10 @@
       "Expanded": "Kiterjesztett",
       "Collapsed": "Összeomlott",
       "SelectAllCheckbox": "Jelölje be az Összes jelölőnégyzetet",
-      "SelectRow": "Válassza ki a sort"
+      "SelectRow": "Válassza ki a sort",
+      "AscendingText": "Növekvő",
+      "DescendingText": "Csökkenő",
+      "NoneText": "Egyik sem"
     },
     "pager": {
       "currentPageInfo": "{1} oldal {0}",

--- a/src/id.json
+++ b/src/id.json
@@ -131,7 +131,10 @@
       "Expanded": "Diperluas",
       "Collapsed": "Runtuh",
       "SelectAllCheckbox": "Pilih Semua Kotak Centang",
-      "SelectRow": "Pilih baris"
+      "SelectRow": "Pilih baris",
+      "AscendingText": "Menaik",
+      "DescendingText": "Menurun",
+      "NoneText": "Tidak ada"
     },
     "pager": {
       "currentPageInfo": "{0} dari {1} halaman",

--- a/src/is.json
+++ b/src/is.json
@@ -86,7 +86,10 @@
       "OR": "EÐA",
       "ShowRowsWhere": "Sýna línur þar sem:",
       "SelectAllCheckbox": "Veldu allt gátreit",
-      "SelectRow": "Veldu röð"
+      "SelectRow": "Veldu röð",
+      "AscendingText": "Vaxandi",
+      "DescendingText": "Minnkandi",
+      "NoneText": "Enginn"
     },
     "pager": {
       "currentPageInfo": "{0} af {1} síðum",

--- a/src/it.json
+++ b/src/it.json
@@ -131,7 +131,10 @@
       "Expanded": "Allargata",
       "Collapsed": "Crollato",
       "SelectAllCheckbox": "Seleziona la casella di controllo Tutto",
-      "SelectRow": "Seleziona riga"
+      "SelectRow": "Seleziona riga",
+      "AscendingText": "Ascendente",
+      "DescendingText": "Discendente",
+      "NoneText": "Nessuno"
     },
     "pager": {
       "currentPageInfo": "{0} di {1} pagine",

--- a/src/ja.json
+++ b/src/ja.json
@@ -131,7 +131,10 @@
       "Expanded": "エキスパンド",
       "Collapsed": "折りたたまれた",
       "SelectAllCheckbox": "すべて選択チェックボックス",
-      "SelectRow": "行を選択"
+      "SelectRow": "行を選択",
+      "AscendingText": "昇順",
+      "DescendingText": "降順",
+      "NoneText": "なし"
     },
     "pager": {
       "currentPageInfo": "{0}ページのうち{1}ページ",

--- a/src/ko.json
+++ b/src/ko.json
@@ -131,7 +131,10 @@
       "Expanded": "퍼지는",
       "Collapsed": "축소됨",
       "SelectAllCheckbox": "모든 체크박스 선택",
-      "SelectRow": "행 선택"
+      "SelectRow": "행 선택",
+      "AscendingText": "오름차순",
+      "DescendingText": "내림차순",
+      "NoneText": "なし"
     },
     "pager": {
       "currentPageInfo": "{1} 페이지 중 {0}",

--- a/src/ms.json
+++ b/src/ms.json
@@ -131,7 +131,10 @@
       "Expanded": "Diperluas",
       "Collapsed": "Runtuh",
       "SelectAllCheckbox": "Pilih Semua Kotak Semak",
-      "SelectRow": "Pilih baris"
+      "SelectRow": "Pilih baris",
+      "AscendingText": "Menaik",
+      "DescendingText": "Menurun",
+      "NoneText": "Tiada"
     },
     "pager": {
       "currentPageInfo": "{0} halaman {1}",

--- a/src/nb.json
+++ b/src/nb.json
@@ -131,7 +131,10 @@
       "Expanded": "Utvidet",
       "Collapsed": "Kollapset",
       "SelectAllCheckbox": "Merk av for Alle",
-      "SelectRow": "Velg rad"
+      "SelectRow": "Velg rad",
+      "AscendingText": "Stigende",
+      "DescendingText": "Fallende",
+      "NoneText": "Ingen"
     },
     "pager": {
       "currentPageInfo": "{0} av {1} sider",

--- a/src/ne-NP.json
+++ b/src/ne-NP.json
@@ -131,7 +131,10 @@
       "Expanded": "विस्तार गरियो",
       "Collapsed": "संक्षिप्त गरियो",
       "SelectAllCheckbox": "सबै चेकबक्स चयन गर्नुहोस्",
-      "SelectRow": "पङ्क्ति चयन गर्नुहोस्"
+      "SelectRow": "पङ्क्ति चयन गर्नुहोस्",
+      "AscendingText": "वर्धनशील",
+      "DescendingText": "घटाउने क्रम",
+      "NoneText": "केही छैन"
     },
     "pager": {
       "currentPageInfo": "{1} पृष्ठहरू मध्ये {0}",

--- a/src/nl.json
+++ b/src/nl.json
@@ -131,7 +131,10 @@
       "Expanded": "uitgebreid",
       "Collapsed": "Ingestort",
       "SelectAllCheckbox": "Selecteer Alles",
-      "SelectRow": "Selecteer rij"
+      "SelectRow": "Selecteer rij",
+      "AscendingText": "Oplopend",
+      "DescendingText": "Aflopend",
+      "NoneText": "Geen"
     },
     "pager": {
       "currentPageInfo": "{0} van {1} pagina's",

--- a/src/pl.json
+++ b/src/pl.json
@@ -131,7 +131,10 @@
       "Expanded": "Rozszerzony",
       "Collapsed": "Zwinięty",
       "SelectAllCheckbox": "Zaznacz pole wyboru Wszystkie",
-      "SelectRow": "Wybierz wiersz"
+      "SelectRow": "Wybierz wiersz",
+      "AscendingText": "Rosnący",
+      "DescendingText": "Malejący",
+      "NoneText": "Żaden"
     },
     "pager": {
       "currentPageInfo": "{0} z {1} stron",

--- a/src/pt-BR.json
+++ b/src/pt-BR.json
@@ -131,7 +131,10 @@
       "Expanded": "Expandida",
       "Collapsed": "Desabou",
       "SelectAllCheckbox": "Caixa de seleção Selecionar tudo",
-      "SelectRow": "Selecione a linha"
+      "SelectRow": "Selecione a linha",
+      "AscendingText": "Crescente",
+      "DescendingText": "Decrescente",
+      "NoneText": "Nenhum"
     },
     "pager": {
       "currentPageInfo": "{0} de {1} páginas",

--- a/src/pt.json
+++ b/src/pt.json
@@ -131,7 +131,10 @@
       "Expanded": "Expandida",
       "Collapsed": "Desabou",
       "SelectAllCheckbox": "Caixa de seleção Selecionar tudo",
-      "SelectRow": "Selecione a linha"
+      "SelectRow": "Selecione a linha",
+      "AscendingText": "Crescente",
+      "DescendingText": "Decrescente",
+      "NoneText": "Nenhum"
     },
     "pager": {
       "currentPageInfo": "{0} de {1} páginas",

--- a/src/ro.json
+++ b/src/ro.json
@@ -131,7 +131,10 @@
       "Expanded": "Extins",
       "Collapsed": "S-a prăbușit",
       "SelectAllCheckbox": "Selectați caseta de selectare Toate",
-      "SelectRow": "Selectați rândul"
+      "SelectRow": "Selectați rândul",
+      "AscendingText": "Ascendent",
+      "DescendingText": "Descendent",
+      "NoneText": "Nimic"
     },
     "pager": {
       "currentPageInfo": "{0} din {1} pagini",

--- a/src/ru.json
+++ b/src/ru.json
@@ -131,7 +131,10 @@
       "Expanded": "Расширенный",
       "Collapsed": "Свернуто",
       "SelectAllCheckbox": "Флажок «Выбрать все»",
-      "SelectRow": "Выберите строку"
+      "SelectRow": "Выберите строку",
+      "AscendingText": "Восходящий",
+      "DescendingText": "Нисходящий",
+      "NoneText": "Никакой"
     },
     "pager": {
       "currentPageInfo": "{0} из {1} страниц",

--- a/src/sk.json
+++ b/src/sk.json
@@ -131,7 +131,10 @@
       "Expanded": "Rozšírené",
       "Collapsed": "Zrútené",
       "SelectAllCheckbox": "Začiarknite políčko Všetky",
-      "SelectRow": "Vyberte riadok"
+      "SelectRow": "Vyberte riadok",
+      "AscendingText": "Stúpajúci",
+      "DescendingText": "Klesajúci",
+      "NoneText": "Žiadny"
     },
     "pager": {
       "currentPageInfo": "{0} z {1} stránok",

--- a/src/sv.json
+++ b/src/sv.json
@@ -131,7 +131,10 @@
       "Expanded": "Expanderat",
       "Collapsed": "Kollapsade",
       "SelectAllCheckbox": "Markera kryssrutan Alla",
-      "SelectRow": "Välj rad"
+      "SelectRow": "Välj rad",
+      "AscendingText": "Stigande",
+      "DescendingText": "Fallende",
+      "NoneText": "Ingen"
     },
     "pager": {
       "currentPageInfo": "{0} av {1} sidor",

--- a/src/th.json
+++ b/src/th.json
@@ -131,7 +131,10 @@
       "Expanded": "ขยาย",
       "Collapsed": "ยุบ",
       "SelectAllCheckbox": "เลือกช่องทำเครื่องหมายทั้งหมด",
-      "SelectRow": "เลือกแถว"
+      "SelectRow": "เลือกแถว",
+      "AscendingText": "เพิ่มขึ้น",
+      "DescendingText": "ลดลง",
+      "NoneText": "ไม่มี"
     },
     "pager": {
       "currentPageInfo": "หน้า {0} จาก {1} หน้า",

--- a/src/tr.json
+++ b/src/tr.json
@@ -131,7 +131,10 @@
       "Expanded": "Genişletilmiş",
       "Collapsed": "çöktü",
       "SelectAllCheckbox": "Tümünü Seç Onay Kutusu",
-      "SelectRow": "Satır seç"
+      "SelectRow": "Satır seç",
+      "AscendingText": "Yükselen",
+      "DescendingText": "Düşen",
+      "NoneText": "Yok"
     },
     "pager": {
       "currentPageInfo": "{1} sayfanın {0}",

--- a/src/vi.json
+++ b/src/vi.json
@@ -131,7 +131,10 @@
       "Expanded": "mở rộng",
       "Collapsed": "Đã thu gọn",
       "SelectAllCheckbox": "Chọn tất cả hộp kiểm",
-      "SelectRow": "Chọn hàng"
+      "SelectRow": "Chọn hàng",
+      "AscendingText": "Tăng dần",
+      "DescendingText": "Giảm dần",
+      "NoneText": "Không có"
     },
     "pager": {
       "currentPageInfo": "{0} trong số {1} trang",

--- a/src/zh.json
+++ b/src/zh.json
@@ -131,7 +131,10 @@
       "Expanded": "展开",
       "Collapsed": "倒塌",
       "SelectAllCheckbox": "选择全部复选框",
-      "SelectRow": "选择行"
+      "SelectRow": "选择行",
+      "AscendingText": "升序",
+      "DescendingText": "降序",
+      "NoneText": "无"
     },
     "pager": {
       "currentPageInfo": "第{0}頁／共{1}頁",


### PR DESCRIPTION
### Bug description

Localization doesn't work for sorting buttons in adaptiveUI

### Root cause

The locale texts for sort ascending , sort descending , none text was not added for adaptiveUI.

### Reason for not identifying earlier

Find how it was missed in our earlier testing and development by analyzing the below checklist. This will help prevent similar mistakes in the future.

- [ ] Guidelines/documents are not followed

- Common guidelines / Core team guideline

- Specification document

- Requirement document

- [ ] Guidelines/documents are not given

- Common guidelines / Core team guideline

- Specification document

- Requirement document

### Reason:

Guidelines/documents are not given - Requirement document

### Action taken:

NA

### Related areas:

Locale, AdaptiveUI

### Is it a breaking issue?

No

### Solution description

The issue was resolved by adding locale for ascending, descending and none text.
 
### Output screenshots
NA

### Areas affected and ensured

Locale, AdaptiveUI

### Additional checklist

This may vary for different teams or products. Check with your scrum masters.

- Did you run the automation against your fix? - Yes

- Is there any API name change? - No

- Is there any existing behavior change of other features due to this code change? - No

- Does your new code introduce new warnings or binding errors? - No

- Does your code pass all FxCop and StyleCop rules? a- No

- Did you record this case in the unit test or UI test? - No
