### PR TITLE
Removed the extra characters in pt and pt-BR json file

### DIFF
--- a/src/pt-BR.json
+++ b/src/pt-BR.json
@@ -2055,7 +2055,7 @@
       "SendBackward": "Enviar um passo a trás"
     },
     "inplace-editor": {
-      "save": "Salvar ",
+      "save": "Salvar",
       "cancel": "Cancelar",
       "loadingText": "Carregando...",
       "editIcon": "Clique para editar",

--- a/src/pt-BR.json
+++ b/src/pt-BR.json
@@ -165,7 +165,7 @@
       "editTitle": "Editar detalhes do card",
       "deleteTitle": "Excluir card",
       "deleteContent": "Tem certeza de que deseja excluir este card?",
-      "save": "Salvar ",
+      "save": "Salvar",
       "delete": "Excluir",
       "cancel": "Cancelar",
       "yes": "Sim",

--- a/src/pt.json
+++ b/src/pt.json
@@ -165,7 +165,7 @@
       "editTitle": "Editar detalhes do cartão",
       "deleteTitle": "Excluir cartão",
       "deleteContent": "Tem certeza de que deseja excluir este cartão?",
-      "save": "Salve ",
+      "save": "Salve",
       "delete": "Excluir",
       "cancel": "Cancelar",
       "yes": "sim",
@@ -2178,7 +2178,7 @@
       "SendBackward": "Enviar para trás"
     },
     "inplace-editor": {
-      "save": "Salve ",
+      "save": "Salve",
       "cancel": "Cancelar",
       "loadingText": "Carregando...",
       "editIcon": "Clique para editar",


### PR DESCRIPTION
### Bug description

Removed the extra characters in pt.json file for In-PlaceEditor and Kanban

### Root cause

Removed the extra characters in pt.json file for In-PlaceEditor and Kanban

### Reason for not identifying earlier

Find how it was missed in our earlier testing and development by analyzing the below checklist. This will help prevent similar mistakes in the future. 

- [x] Guidelines/documents are not followed

    - [x] Common guidelines / Core team guideline
    - Specification document
    - Requirement document

- [ ] Guidelines/documents are not given


    - Common guidelines / Core team guideline
    - Specification document
    - Requirement document


### Reason:

Removed the extra characters in pt.json file for In-PlaceEditor and Kanban

### Action taken:

Removed the extra characters in pt.json file for In-PlaceEditor and Kanban

### Related areas:

Ensured culture values

### Is it a breaking issue?

No

### Solution description

Added config to generate newly added culture codes.

### Areas affected and ensured

Ensured culture values

### Additional checklist

  - Did you run the automation against your fix? NA
  - Is there any API name change? No
  - Is there any existing behavior change of other features due to this code change? No
  - Does your new code introduce new warnings or binding errors? No
  - Does your code pass all FxCop and StyleCop rules? NA
  - Did you record this case in the unit test or UI test? NA