### PR TITLE
915059: Incorrect ClearFilter Translation in es Locale for Grid Component.

### DIFF
--- a/src/es.json
+++ b/src/es.json
@@ -72,7 +72,7 @@
       "FilterTrue": "Cierto",
       "FilterFalse": "Falso",
       "NoResult": "No se encontraron coincidencias",
-      "ClearFilter": "Filtro claro",
+      "ClearFilter": "Borrar filtro",
       "NumberFilter": "Filtros de número",
       "TextFilter": "Filtros de texto",
       "DateFilter": "Filtros de fecha",


### PR DESCRIPTION
### Bug description

The translation for the ClearFilter text in the es.json locale of the Grid component is incorrect.

### Root cause

The issue arises due to an incorrect text used for ClearFilter in the es locale file.

### Reason for not identifying earlier

Find how it was missed in our earlier testing and development by analyzing the below checklist. This will help prevent similar mistakes in the future.

- [ ] Guidelines/documents are not followed

- Common guidelines / Core team guideline

- Specification document

- Requirement document

- [x] Guidelines/documents are not given

- Common guidelines / Core team guideline

- Specification document

- Requirement document

### Reason:

Guidelines/documents are not given - Requirement document

### Action taken:

NA

### Related areas:

ClearFilter keyword in Grid component.

### Is it a breaking issue?

No

### Solution description

The issue was resolved by updating the ClearFilter value to Borrar filtro, which is the correct translation, replacing the incorrect Filtro claro.
 
### Output screenshots
![image](https://github.com/user-attachments/assets/39114261-9b75-4f9e-a539-0c8c9801e9fc)


### Areas affected and ensured

es.json file

### Additional checklist

This may vary for different teams or products. Check with your scrum masters.

- Did you run the automation against your fix? - No

- Is there any API name change? - No

- Is there any existing behavior change of other features due to this code change? - No

- Does your new code introduce new warnings or binding errors? - No

- Does your code pass all FxCop and StyleCop rules? a- No

- Did you record this case in the unit test or UI test? - No
