### PR TITLE
912851: Document editor dutch casing letter issue resolved

### DIFF
--- a/src/nl.json
+++ b/src/nl.json
@@ -2900,7 +2900,7 @@
       "Bottom margin": "Ondermarge",
       "Left margin": "Linkermarge",
       "Right margin": "Rechtermarge",
-      "Normal": "normaal",
+      "Normal": "Normaal",
       "Heading": "Kop",
       "Heading 1": "Koptekst 1",
       "Heading 2": "Koptekst 2",


### PR DESCRIPTION
**Description:**

Updated the document editor casing letter for normal for dutch language. 