### PR TITLE
915034: Remove unwanted characters from pt and pt-BR

### DIFF
--- a/src/pt-BR.json
+++ b/src/pt-BR.json
@@ -2291,7 +2291,7 @@
       "Delete Column": "Excluir coluna",
       "File Name": "Nome do arquivo",
       "Format Type": "Tipo de formato",
-      "Save": "Salvar ",
+      "Save": "Salvar",
       "Navigation": "Navegação",
       "Results": "Resultados",
       "Replace": "Substituir",

--- a/src/pt.json
+++ b/src/pt.json
@@ -2414,7 +2414,7 @@
       "Delete Column": "Excluir coluna",
       "File Name": "Nome do arquivo",
       "Format Type": "Tipo de formato",
-      "Save": "Salve ",
+      "Save": "Salve",
       "Navigation": "Navegação",
       "Results": "Resultados",
       "Replace": "Substituir",


### PR DESCRIPTION
### Bug description

Removed the extra characters in pt.json file for Document editor

### Root cause

Removed the extra characters in pt.json file for Document editor

### Reason for not identifying earlier

Find how it was missed in our earlier testing and development by analyzing the below checklist. This will help prevent similar mistakes in the future. 

- [x] Guidelines/documents are not followed

    - [x] Common guidelines / Core team guideline
    - Specification document
    - Requirement document

- [ ] Guidelines/documents are not given


    - Common guidelines / Core team guideline
    - Specification document
    - Requirement document


### Reason:

Removed the extra characters in pt.json file for Document editor

### Action taken:

Removed the extra characters in pt.json file for Document editor

### Related areas:

Ensured culture values

### Is it a breaking issue?

No

### Solution description

Added config to generate newly added culture codes.

### Areas affected and ensured

Ensured culture values

### Additional checklist

  - Did you run the automation against your fix? NA
  - Is there any API name change? No
  - Is there any existing behavior change of other features due to this code change? No
  - Does your new code introduce new warnings or binding errors? No
  - Does your code pass all FxCop and StyleCop rules? NA
  - Did you record this case in the unit test or UI test? NA